### PR TITLE
Test the match between the CLI args and Config.__init__'s

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,8 @@
 import os
 import setuptools
 
+import wikipron
+
 
 if getattr(setuptools, "__version__", "0") < "39":
     # v36.4.0+ needed to automatically include README.md in packaging
@@ -16,16 +18,14 @@ _THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 with open(os.path.join(_THIS_DIR, "README.md")) as f:
     _LONG_DESCRIPTION = f.read().strip()
 
-__version__ = "0.1.0"
-
 
 def main():
     setuptools.setup(
         name="wikipron",
-        version=__version__,
+        version=wikipron.__version__,
         author="Kyle Gorman, Jackson Lee, Elizabeth Garza",
         author_email="kylebgorman@gmail.com",
-        description="Scraping grapheme-to-phoneme (G2P) data from Wiktionary",
+        description=wikipron.__doc__,
         long_description=_LONG_DESCRIPTION,
         long_description_content_type="text/markdown",
         url="https://github.com/kylebgorman/wikipron",

--- a/test_wikipron.py
+++ b/test_wikipron.py
@@ -1,4 +1,5 @@
 import datetime
+import inspect
 import os
 import re
 import shutil
@@ -14,6 +15,7 @@ from wikipron import (
     _PAGE_TEMPLATE,
     _PHONEMES_REGEX,
     _PHONES_REGEX,
+    _get_cli_args,
     scrape,
 )
 
@@ -274,4 +276,12 @@ def test_terminal_command():
         f'The command "{_TERMINAL_COMMAND}" exists but does not work. '
         f'The smoke test with "{smoke_test_command}" may have diagnostic '
         "information to stderr."
+    )
+
+
+def test_cli_args_match_config_args():
+    config_args = inspect.getfullargspec(Config.__init__)
+    cli_args = _get_cli_args(["eng"])
+    assert cli_args.__dict__ == {**config_args.kwonlydefaults, "key": "eng"}, (
+        "CLI and Config.__init__ must have the same args and their defaults."
     )

--- a/wikipron.py
+++ b/wikipron.py
@@ -7,7 +7,7 @@ import logging
 import re
 import sys
 
-from typing import Callable, Iterator, Optional, TextIO, Tuple
+from typing import Callable, Iterator, List, Optional, TextIO, Tuple
 
 import iso639
 import requests
@@ -274,8 +274,7 @@ def _scrape_and_write(config: Config) -> None:
             logging.info("%d pronunciations scraped", i)
 
 
-def main() -> None:
-    logging.basicConfig(format="%(levelname)s: %(message)s", level="INFO")
+def _get_cli_args(args: List[str]) -> argparse.Namespace:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument(
         "key", help="Key (i.e., name or ISO-639 code) for the language"
@@ -337,6 +336,11 @@ def main() -> None:
             "overridden. If not given, results appear in stdout."
         ),
     )
-    args = parser.parse_args()
+    return parser.parse_args(args)
+
+
+def main() -> None:
+    logging.basicConfig(format="%(levelname)s: %(message)s", level="INFO")
+    args = _get_cli_args(sys.argv[1:])
     config = Config(**args.__dict__)
     _scrape_and_write(config)

--- a/wikipron.py
+++ b/wikipron.py
@@ -1,4 +1,4 @@
-"""Scraping Wiktionary data."""
+"""Scraping grapheme-to-phoneme data from Wiktionary."""
 
 import argparse
 import datetime
@@ -12,6 +12,9 @@ from typing import Callable, Iterator, List, Optional, TextIO, Tuple
 import iso639
 import requests
 import requests_html
+
+
+__version__ = "0.1.0"
 
 Pair = Tuple[str, str]
 


### PR DESCRIPTION
For the CLI to work, an implicit but critical assumption is that the CLI args and their defaults are exactly those of `Config.__init__`. This PR adds a test to formally check that. (Previously I had had [this dummy class](https://github.com/kylebgorman/wikipron/pull/38/files#diff-037a040a2a7ab00ebc787ca74ebf5a53L29) to exercise the CLI interface in the test suite, which might have been overkill. I hope you think the new test in this PR is lightweight enough!)