### PR TITLE
Handle Estonian, Slovak, etc. for title="wikipedia:<language> phonology"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 ### Removed
 ### Fixed
+- Updated the `<li>` XPath selector for `title="wikipedia:<language> phonology"`
+  to cover languages (e.g., Estonian and Slovak) we previously couldn't
+  scrape data for. (#49)
+
 ### Security
 
 ## [0.1.1] - 2019-08-14

--- a/test_wikipron.py
+++ b/test_wikipron.py
@@ -122,9 +122,11 @@ def test_ipa_regex(phonetic, ipa_regex, word_in_ipa):
             False,
             (
                 "\n//li[\n"
-                '  (sup[a[@title = "Appendix:English pronunciation"]]\n'
-                "   or\n"
-                '   sup[a[@title = "wikipedia:English phonology"]])\n'
+                "  sup[a[\n"
+                '    @title = "Appendix:English pronunciation"\n'
+                "    or\n"
+                '    @title = "wikipedia:English phonology"\n'
+                "  ]]\n"
                 "  and\n"
                 '  span[@class = "IPA"]\n'
                 "  and\n"
@@ -138,9 +140,11 @@ def test_ipa_regex(phonetic, ipa_regex, word_in_ipa):
             False,
             (
                 "\n//li[\n"
-                '  (sup[a[@title = "Appendix:English pronunciation"]]\n'
-                "   or\n"
-                '   sup[a[@title = "wikipedia:English phonology"]])\n'
+                "  sup[a[\n"
+                '    @title = "Appendix:English pronunciation"\n'
+                "    or\n"
+                '    @title = "wikipedia:English phonology"\n'
+                "  ]]\n"
                 "  and\n"
                 '  span[@class = "IPA"]\n'
                 "  and\n"
@@ -154,9 +158,11 @@ def test_ipa_regex(phonetic, ipa_regex, word_in_ipa):
             True,
             (
                 "\n//li[\n"
-                '  (sup[a[@title = "Appendix:English pronunciation"]]\n'
-                "   or\n"
-                '   sup[a[@title = "wikipedia:English phonology"]])\n'
+                "  sup[a[\n"
+                '    @title = "Appendix:English pronunciation"\n'
+                "    or\n"
+                '    @title = "wikipedia:English phonology"\n'
+                "  ]]\n"
                 "  and\n"
                 '  span[@class = "IPA"]\n'
                 "  and\n"
@@ -169,9 +175,11 @@ def test_ipa_regex(phonetic, ipa_regex, word_in_ipa):
             False,
             (
                 "\n//li[\n"
-                '  (sup[a[@title = "Appendix:English pronunciation"]]\n'
-                "   or\n"
-                '   sup[a[@title = "wikipedia:English phonology"]])\n'
+                "  sup[a[\n"
+                '    @title = "Appendix:English pronunciation"\n'
+                "    or\n"
+                '    @title = "wikipedia:English phonology"\n'
+                "  ]]\n"
                 "  and\n"
                 '  span[@class = "IPA"]\n'
                 "  and\n"

--- a/test_wikipron.py
+++ b/test_wikipron.py
@@ -241,11 +241,20 @@ def test_require_dialect_label():
 
 
 @pytest.mark.skipif(not _can_connect_to_wiktionary(), reason="need Internet")
+@pytest.mark.parametrize(
+    "key, language",
+    [
+        ("eng", "English"),
+        # Test that 'sup[a[@title = "wikipedia:Slovak phonology"]]' works.
+        ("slk", "Slovak"),
+    ],
+)
 @pytest.mark.timeout(2)
-def test_scrape():
+def test_scrape(key, language):
     """A smoke test for scrape()."""
     n = 10  # number of word-pron pairs to scrape
-    config = _config_factory()
+    config = _config_factory(key=key)
+    assert config.language == language
     pairs = []
     for i, (word, pron) in enumerate(scrape(config)):
         if i >= n:

--- a/test_wikipron.py
+++ b/test_wikipron.py
@@ -122,7 +122,9 @@ def test_ipa_regex(phonetic, ipa_regex, word_in_ipa):
             False,
             (
                 "\n//li[\n"
-                '  sup[a[@title = "Appendix:English pronunciation"]]\n'
+                '  (sup[a[@title = "Appendix:English pronunciation"]]\n'
+                "   or\n"
+                '   sup[a[@title = "wikipedia:English phonology"]])\n'
                 "  and\n"
                 '  span[@class = "IPA"]\n'
                 "  and\n"
@@ -136,7 +138,9 @@ def test_ipa_regex(phonetic, ipa_regex, word_in_ipa):
             False,
             (
                 "\n//li[\n"
-                '  sup[a[@title = "Appendix:English pronunciation"]]\n'
+                '  (sup[a[@title = "Appendix:English pronunciation"]]\n'
+                "   or\n"
+                '   sup[a[@title = "wikipedia:English phonology"]])\n'
                 "  and\n"
                 '  span[@class = "IPA"]\n'
                 "  and\n"
@@ -150,7 +154,9 @@ def test_ipa_regex(phonetic, ipa_regex, word_in_ipa):
             True,
             (
                 "\n//li[\n"
-                '  sup[a[@title = "Appendix:English pronunciation"]]\n'
+                '  (sup[a[@title = "Appendix:English pronunciation"]]\n'
+                "   or\n"
+                '   sup[a[@title = "wikipedia:English phonology"]])\n'
                 "  and\n"
                 '  span[@class = "IPA"]\n'
                 "  and\n"
@@ -163,7 +169,9 @@ def test_ipa_regex(phonetic, ipa_regex, word_in_ipa):
             False,
             (
                 "\n//li[\n"
-                '  sup[a[@title = "Appendix:English pronunciation"]]\n'
+                '  (sup[a[@title = "Appendix:English pronunciation"]]\n'
+                "   or\n"
+                '   sup[a[@title = "wikipedia:English phonology"]])\n'
                 "  and\n"
                 '  span[@class = "IPA"]\n'
                 "  and\n"

--- a/wikipron.py
+++ b/wikipron.py
@@ -44,9 +44,11 @@ _CONTINUE_TEMPLATE = _INITIAL_QUERY_TEMPLATE + "&cmcontinue={cmcontinue}"
 _PAGE_TEMPLATE = "https://en.wiktionary.org/wiki/{word}"
 _LI_SELECTOR_TEMPLATE = """
 //li[
-  (sup[a[@title = "Appendix:{language} pronunciation"]]
-   or
-   sup[a[@title = "wikipedia:{language} phonology"]])
+  sup[a[
+    @title = "Appendix:{language} pronunciation"
+    or
+    @title = "wikipedia:{language} phonology"
+  ]]
   and
   span[@class = "IPA"]
   and

--- a/wikipron.py
+++ b/wikipron.py
@@ -44,7 +44,9 @@ _CONTINUE_TEMPLATE = _INITIAL_QUERY_TEMPLATE + "&cmcontinue={cmcontinue}"
 _PAGE_TEMPLATE = "https://en.wiktionary.org/wiki/{word}"
 _LI_SELECTOR_TEMPLATE = """
 //li[
-  sup[a[@title = "Appendix:{language} pronunciation"]]
+  (sup[a[@title = "Appendix:{language} pronunciation"]]
+   or
+   sup[a[@title = "wikipedia:{language} phonology"]])
   and
   span[@class = "IPA"]
   and


### PR DESCRIPTION
For whatever reason, languages like Estonian and Slovak use `title="wikipedia:<language> phonology"` (as opposed to `Appendix:<language> pronunciation` that we've seen for other languages we've scraped so far) in the underlying HTML to signal a pronunciation. This PR expands the `<li>` XPath selector to coverage these languages. To make sure the change works, I've updated the smoke test to include Slovak.