### PR TITLE
Resolve Wiktionary names for Okinawan and Ottoman Turkish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Resolved Wiktionary language names for languages with at least 100
-  pronunciation entries. (#52)
+  pronunciation entries. (#52, #55)
 
 ### Changed
 ### Deprecated

--- a/tests/test_languagecodes.py
+++ b/tests/test_languagecodes.py
@@ -106,5 +106,5 @@ def test_language_coverage():
 
 def test_language_codes_dict_keys():
     """LANGUAGE_CODES keys must be in lowercase for Config._get_language."""
-    for k, v in LANGUAGE_CODES.items():
+    for k in LANGUAGE_CODES.keys():
         assert k == k.lower()

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -232,4 +232,11 @@ LANGUAGE_CODES = {
     "dimli": "Zazaki",
     "kirdki": "Zazaki",
     "kirmanjki": "Zazaki",
+    # Okinawan. ISO 639-3 only.
+    "ryu": "Okinawan",
+    "okinawan": "Okinawan",
+    "central okinawan": "Okinawan",
+    # Ottoman Turkish. Would be "Ottoman Turkish (1500-1928)" in ISO 639.
+    "ota": "Ottoman Turkish",
+    "ottoman turkish": "Ottoman Turkish",
 }


### PR DESCRIPTION
It looks like the community has just contributed more data to these languages and hence the warnings in the CI builds:

```
=============================== warnings summary ===============================
tests/test_languagecodes.py::test_language_coverage
  /root/project/tests/test_languagecodes.py:97: UserWarning: WikiPron cannot handle "Okinawan".
    warnings.warn(f'WikiPron cannot handle "{language}".')

tests/test_languagecodes.py::test_language_coverage
  /root/project/tests/test_languagecodes.py:97: UserWarning: WikiPron cannot handle "Ottoman Turkish".
    warnings.warn(f'WikiPron cannot handle "{language}".')
```

This PR resolves Wiktionary names for Okinawan and Ottoman Turkish.