### PR TITLE
Skip empty pronunciations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 ### Removed
 ### Fixed
+- Skipped empty pronunciations in scraping. (#58)
 - Updated the `<li>` XPath selector for an optional layer of `<span>`
   to cover previously unhandled languages (e.g., Korean). (#50) 
 - Updated the `<li>` XPath selector for `title="wikipedia:<language> phonology"`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Deprecated
 ### Removed
 ### Fixed
-- Skipped empty pronunciations in scraping. (#58)
+- Skipped empty pronunciations in scraping. (#59)
 - Updated the `<li>` XPath selector for an optional layer of `<span>`
   to cover previously unhandled languages (e.g., Korean). (#50) 
 - Updated the `<li>` XPath selector for `title="wikipedia:<language> phonology"`

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,19 +36,23 @@ def test_casefold(casefold, input_word, expected_word):
 
 
 @pytest.mark.parametrize(
-    "no_stress, no_syllable_boundaries, expected_pron",
+    "no_stress, no_syllable_boundaries, input_pron, expected_pron",
     [
-        (True, True, "lɪŋɡwɪstɪks"),
-        (True, False, "lɪŋ.ɡwɪs.tɪks"),
-        (False, True, "lɪŋˈɡwɪstɪks"),
-        (False, False, "lɪŋ.ˈɡwɪs.tɪks"),
+        (True, True, "lɪŋ.ˈɡwɪs.tɪks", "lɪŋɡwɪstɪks"),
+        (True, False, "lɪŋ.ˈɡwɪs.tɪks", "lɪŋ.ɡwɪs.tɪks"),
+        (False, True, "lɪŋ.ˈɡwɪs.tɪks", "lɪŋˈɡwɪstɪks"),
+        (False, False, "lɪŋ.ˈɡwɪs.tɪks", "lɪŋ.ˈɡwɪs.tɪks"),
+        # GH-59: Prons with only stress or syllable boundaries are skipped.
+        (False, False, "ˈ", None),
     ],
 )
-def test_process_pron(no_stress, no_syllable_boundaries, expected_pron):
+def test_process_pron(
+    no_stress, no_syllable_boundaries, input_pron, expected_pron
+):
     config = config_factory(
         no_stress=no_stress, no_syllable_boundaries=no_syllable_boundaries
     )
-    assert config.process_pron("lɪŋ.ˈɡwɪs.tɪks") == expected_pron
+    assert config.process_pron(input_pron) == expected_pron
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -44,6 +44,7 @@ def test_casefold(casefold, input_word, expected_word):
         (False, False, "lɪŋ.ˈɡwɪs.tɪks", "lɪŋ.ˈɡwɪs.tɪks"),
         # GH-59: Prons with only stress or syllable boundaries are skipped.
         (False, False, "ˈ", None),
+        (False, False, "", None),
     ],
 )
 def test_process_pron(

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -127,16 +127,16 @@ class Config:
         if no_syllable_boundaries:
             processors.append(functools.partial(re.sub, r"\.", ""))
 
+        prosodic_markers = frozenset(["ˈ", "ˌ", "."])
+
         def wrapper(pron):
             for processor in processors:
                 pron = processor(pron)
             # GH-59: Skip prons that are empty, or have only stress marks or
             # syllable boundaries. The `any()` call is much faster than
             # re.match(r"[^ˈˌ.]", pron).
-            if any(c not in "ˈˌ." for c in pron):
+            if any(c not in prosodic_markers for c in pron):
                 return pron
-            else:
-                return None
 
         return wrapper
 

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -130,7 +130,13 @@ class Config:
         def wrapper(pron):
             for processor in processors:
                 pron = processor(pron)
-            return pron
+            # GH-59: Skip prons that are empty, or have only stress marks or
+            # syllable boundaries. The `any()` call is much faster than
+            # re.match(r"[^ˈˌ.]", pron).
+            if any(c not in "ˈˌ." for c in pron):
+                return pron
+            else:
+                return None
 
         return wrapper
 

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -48,10 +48,7 @@ def _scrape_once(data, config: Config) -> Iterator[Pair]:
             if " " in pron:
                 continue
             pron = config.process_pron(pron)
-            # GH-59: Skip prons that are empty, or have only stress marks or
-            # syllable boundaries. The `any()` call is much faster than
-            # re.match(r"[^ˈˌ.]", pron).
-            if any(c not in "ˈˌ." for c in pron):
+            if pron:
                 yield (word, pron)
 
 
@@ -68,8 +65,7 @@ def scrape(config: Config) -> Iterator[Pair]:
     }
     while True:
         data = requests.get(
-            "https://en.wiktionary.org/w/api.php?",
-            params=requests_params,
+            "https://en.wiktionary.org/w/api.php?", params=requests_params
         ).json()
         yield from _scrape_once(data, config)
         if "continue" not in data:

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -48,7 +48,8 @@ def _scrape_once(data, config: Config) -> Iterator[Pair]:
             if " " in pron:
                 continue
             pron = config.process_pron(pron)
-            yield (word, pron)
+            if pron:
+                yield (word, pron)
 
 
 def scrape(config: Config) -> Iterator[Pair]:

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -48,7 +48,7 @@ def _scrape_once(data, config: Config) -> Iterator[Pair]:
             if " " in pron:
                 continue
             pron = config.process_pron(pron)
-            # GH-59: Skip prons that are empty, or has only stress marks or
+            # GH-59: Skip prons that are empty, or have only stress marks or
             # syllable boundaries. The `any()` call is much faster than
             # re.match(r"[^ˈˌ.]", pron).
             if any(c not in "ˈˌ." for c in pron):

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -48,7 +48,10 @@ def _scrape_once(data, config: Config) -> Iterator[Pair]:
             if " " in pron:
                 continue
             pron = config.process_pron(pron)
-            if pron:
+            # GH-59: Skip prons that are empty, or has only stress marks or
+            # syllable boundaries. The `any()` call is much faster than
+            # re.match(r"[^ˈˌ.]", pron).
+            if any(c not in "ˈˌ." for c in pron):
                 yield (word, pron)
 
 


### PR DESCRIPTION
This PR fixes the bug that we previously got scraped data where a pronunciation could be "empty" (= with only stress marks or syllable boundaries, or truly empty).

An example pronunciation in point brought up by @yeonju123 is https://en.wiktionary.org/wiki/marcap%C3%A1ginas, where the Spanish pronunciation is strangely a stress mark only as `/ˈ/` at the time of writing.

Resolves #58.