### PR TITLE
add flag for whitespace delimited segementation

### DIFF
--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -38,10 +38,10 @@ def test_casefold(casefold, input_word, expected_word):
 @pytest.mark.parametrize(
     "no_stress, no_syllable_boundaries, input_pron, expected_pron",
     [
-        (True, True, "lɪŋ.ˈɡwɪs.tɪks", "lɪŋɡwɪstɪks"),
-        (True, False, "lɪŋ.ˈɡwɪs.tɪks", "lɪŋ.ɡwɪs.tɪks"),
-        (False, True, "lɪŋ.ˈɡwɪs.tɪks", "lɪŋˈɡwɪstɪks"),
-        (False, False, "lɪŋ.ˈɡwɪs.tɪks", "lɪŋ.ˈɡwɪs.tɪks"),
+        (True, True, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ ɡ w ɪ s t ɪ k s"),
+        (True, False, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ . ɡ w ɪ s . t ɪ k s"),
+        (False, True, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ ˈ ɡ w ɪ s t ɪ k s"),
+        (False, False, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ . ˈ ɡ w ɪ s . t ɪ k s"),
         # GH-59: Prons with only stress or syllable boundaries are skipped.
         (False, False, "ˈ", None),
         (False, False, "", None),
@@ -53,6 +53,18 @@ def test_process_pron(
     config = config_factory(
         no_stress=no_stress, no_syllable_boundaries=no_syllable_boundaries
     )
+    assert config.process_pron(input_pron) == expected_pron
+
+
+@pytest.mark.parametrize(
+    "no_segment, input_pron, expected_pron",
+    [
+        (False, "lɛ̃.ɡɥis.tik", "l ɛ̃ . ɡ ɥ i s . t i k"),
+        (True, "lɛ̃.ɡɥis.tik", "lɛ̃.ɡɥis.tik"),
+    ],
+)
+def test_no_segment(no_segment, input_pron, expected_pron):
+    config = config_factory(no_segment=no_segment)
     assert config.process_pron(input_pron) == expected_pron
 
 

--- a/wikipron/cli.py
+++ b/wikipron/cli.py
@@ -71,6 +71,11 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
             "overridden. If not given, results appear in stdout."
         ),
     )
+    parser.add_argument(
+        "--no-segment",
+        action="store_true",
+        help="Disable IPA segmentation with added whitespace."
+    )
     return parser.parse_args(args)
 
 


### PR DESCRIPTION
In response to scraping issue #64 (IPA symbol segmentation), I'm proposing some changes to `wikipron/cli.py` and `wikipron/config.py`. This will add a flag,`--segment`, for use on the command line. The actual execution takes place under the `_get_proccess_pron()` method in the `Config` class. This seemed like the most natural place to put it, since the pronunciations undergo other transformations there as well. I've tested the code by scraping Spanish (phonetic) and French  (phonemic) and it appears to work well.