### PR TITLE
Tightens versioning for `segments`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,9 @@ Unreleased
 
 -   Handled Khmer, whose pronunciations are embedded in HTML tables. (\#88)
 -   IPA segmentation using spaces by default, with the `--no-segment` flag to
-    optionally turn it off. (\#69, \#79, \#83)
+    optionally turn it off. (\#69, \#79, \#83, \#89)
 -   TSV files for all Wiktionary languages with over 1000 entries (except
-    Russian) (\#61)
+    Russian). (\#61)
 -   Resolved Wiktionary language names for languages with at least 100
     pronunciation entries. (\#52, \#55)
 
@@ -55,4 +55,4 @@ Unreleased
 [0.1.0] - 2019-08-14
 ----------------------
 
-First Release
+First release.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pytest==5.0.1
 pytest-timeout==1.3.3
 requests==2.21.0
 requests-html==0.9.0
-segments==2.1.1
+segments>=2.1.2,<3
 setuptools==41.4.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,5 +4,5 @@ pytest==5.0.1
 pytest-timeout==1.3.3
 requests==2.21.0
 requests-html==0.9.0
-segments>=2.1.2,<3
+segments==2.1.2
 setuptools==41.4.0

--- a/setup.py
+++ b/setup.py
@@ -43,9 +43,9 @@ def main():
         zip_safe=False,
         install_requires=[
             "iso639",
-            "segments < 3",
             "requests",
             "requests-html",
+            "segments>=2.1.2,<3",
             "setuptools",
         ],
         entry_points={"console_scripts": ["wikipron = wikipron.cli:main"]},

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -128,14 +128,12 @@ class Config:
         prosodic_markers = frozenset(["ˈ", "ˌ", "."])
 
         def wrapper(pron):
-            # GH-59: Skip prons that are empty, or have only stress marks or
-            # syllable boundaries. The `any()` call is much faster than
-            # re.match(r"[^ˈˌ.]", pron).
-            if all(ch in prosodic_markers for ch in pron):
-                return
             for processor in processors:
                 pron = processor(pron)
-            return pron
+            # GH-59: Skip prons that are empty, or have only stress marks or
+            # syllable boundaries.
+            if any(ch not in prosodic_markers for ch in pron):
+                return pron
 
         return wrapper
 


### PR DESCRIPTION
Upstream, `segments` incorporated [a fix we proposed](https://github.com/cldf/segments/commit/d74a23c53bd9f25f5a90f45a5068e6284d4a7708). I make sure the version we use is at least that high. I then revert [a minor change made to avoid the underlying issue](https://github.com/cldf/segments/commit/d74a23c53bd9f25f5a90f45a5068e6284d4a7708).