### PR TITLE
Factor out casefolding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,11 +13,11 @@ Unreleased
 ### Added
 
 -   Handled Latin, for which the actual graphemes cannot be the Wiktionary
-    page titles and have to come from within the page. (\# 92, \# 93)
+    page titles and have to come from within the page. (\#92, \#93)
 -   Handled Thai, whose pronunciations are embedded in HTML tables. (\#90)
 -   Handled Khmer, whose pronunciations are embedded in HTML tables. (\#88)
 -   IPA segmentation using spaces by default, with the `--no-segment` flag to
-    optionally turn it off. (\#69, \#79, \#83, \#89)
+    optionally turn it off. (\#69, \#79, \#83, \#89, \#100)
 -   TSV files for all Wiktionary languages with over 1000 entries (except
     Russian). (\#61)
 -   Resolved Wiktionary language names for languages with at least 100
@@ -25,6 +25,7 @@ Unreleased
 
 ### Changed
 
+-   Factored out casefolding. (\#102)
 -   Generalized word and pronunciation extraction. (\#88)
 
 ### Deprecated

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -156,6 +156,12 @@ class Config:
 
     def _get_extract_word_pron(self, language: str) -> ExtractFunc:
         try:
-            return EXTRACTION_FUNCTIONS[language]
+            extraction_function = EXTRACTION_FUNCTIONS[language]
         except KeyError:
-            return extract_word_pron_default
+            extraction_function = extract_word_pron_default
+
+        def extract_word_pron_with_casefolding(*args, **kwargs):
+            for word, pron in extraction_function(*args, **kwargs):
+                yield self.casefold(word), pron
+
+        return extract_word_pron_with_casefolding

--- a/wikipron/extract/default.py
+++ b/wikipron/extract/default.py
@@ -26,6 +26,6 @@ def _yield_phn(
 def extract_word_pron_default(
     word: "Word", request: requests.Response, config: "Config"
 ) -> "Iterator[WordPronPair]":
-    words = itertools.repeat(config.casefold(word))
+    words = itertools.repeat(word)
     prons = _yield_phn(request, config)
     yield from zip(words, prons)

--- a/wikipron/extract/khm.py
+++ b/wikipron/extract/khm.py
@@ -19,6 +19,6 @@ _IPA_XPATH_SELECTOR = '//span[@class = "IPA" and @lang = "km"]'
 def extract_word_pron_khmer(
     word: "Word", request: requests.Response, config: "Config"
 ) -> "Iterator[WordPronPair]":
-    words = itertools.repeat(config.casefold(word))
+    words = itertools.repeat(word)
     prons = yield_pron(request.html, _IPA_XPATH_SELECTOR, config)
     yield from zip(words, prons)

--- a/wikipron/extract/tha.py
+++ b/wikipron/extract/tha.py
@@ -16,6 +16,6 @@ if typing.TYPE_CHECKING:
 def extract_word_pron_thai(
     word: "Word", request: requests.Response, config: "Config"
 ) -> "Iterator[WordPronPair]":
-    words = itertools.repeat(config.casefold(word))
+    words = itertools.repeat(word)
     prons = yield_pron(request.html, IPA_XPATH_SELECTOR, config)
     yield from zip(words, prons)


### PR DESCRIPTION
Whether to casefold or not should be a call (both literally and computer-code-wise) made inside the `Config` instance, but not at the individual word pron extraction functions.

Resolves #99. I've tested that the fix works for both Latin and other languages, both for whether `--casefold` is applied or not.