### PR TITLE
Increased coverage of language codes not in iso639 lib

### DIFF
--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -259,5 +259,7 @@ LANGUAGE_CODES = {
     # Mandarin Chinese. ISO 639-3 only.
     "cmn": "Chinese",
     # Abkhaz. Would be Abkhazian in ISO 639.
-    "abk": "Abkhaz"
+    "abk": "Abkhaz",
+    # Avar. Would be Avaric in ISO 639.
+    "ava": "Avar"
 }

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -261,5 +261,7 @@ LANGUAGE_CODES = {
     # Abkhaz. Would be Abkhazian in ISO 639.
     "abk": "Abkhaz",
     # Avar. Would be Avaric in ISO 639.
-    "ava": "Avar"
+    "ava": "Avar",
+    # Buryat. Would be Buriat in ISO 639.
+    "bua": "Buryat",
 }

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -264,4 +264,6 @@ LANGUAGE_CODES = {
     "ava": "Avar",
     # Buryat. Would be Buriat in ISO 639.
     "bua": "Buryat",
+    # Chukchi. Would be Chukot in ISO 639.
+    "ckt": "Chukchi",
 }

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -253,7 +253,7 @@ LANGUAGE_CODES = {
     # Bouyei. ISO 639-3 only.
     "pcc": "Bouyei",
     # Lamboya. ISO 639-3 only.
-    "lmy": "Lamboya",
+    "lmy": "Laboya",
     # Moroccan Arabic. ISO 639-3 only.
     "ary": "Moroccan Arabic",
     # Mandarin Chinese. ISO 639-3 only.
@@ -268,8 +268,6 @@ LANGUAGE_CODES = {
     "ckt": "Chukchi",
     # Burushaski. ISO 639-3 only.
     "bsk": "Burushaski",
-    # Galician. Not in iso639 lib.
-    "glc": "Galician",
     # Evenki. Not in iso639 lib.
     "evn": "Evenki",
     # Southern Yukaghir. Not in iso639 lib.

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -298,4 +298,16 @@ LANGUAGE_CODES = {
     "koi": "Komi-Permyak",
     # Komi-Zyrian. Not in iso639 lib.
     "kpv": "Komi-Zyrian",
+    # Lak. Not in iso639 lib.
+    "lbe": "Lak",
+    # Lezgi. Would be Lezghian in ISO 639.
+    "lez": "Lezgi",
+    # Eastern Mari. Not in iso639 lib.
+    "mhr": "Eastern Mari",
+    # Mansi. Not in iso639 lib.
+    "mns": "Mansi",
+    # Nganasan. Not in iso639 lib.
+    "nio": "Nganasan",
+    # Nivkh. Not in iso639 lib.
+    "niv": "Nivkh",
 }

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -276,4 +276,26 @@ LANGUAGE_CODES = {
     "yux": "Southern Yukaghir",
     # Tundra Nenets. Not in iso639 lib.
     "yrk": "Tundra Nenets",
+    # Estonian. Not in iso639 lib.
+    "ekk": "Estonian",
+    # Livvi. Not in iso639 lib.
+    "olo": "Livvi",
+    # Kildin Sami. Not in iso639 lib.
+    "sjd": "Kildin Sami",
+    # Northern Yukaghir. Not in iso639 lib.
+    "ykg": "Northern Yukaghir",
+    # Nanai. Not in iso639 lib.
+    "gld": "Nanai",
+    # Persian. Not in iso639 lib.
+    "pes": "Persian",
+    # Greenlandic. Would be Kalaallisut in ISO 639.
+    "kal": "Greenlandic",
+    # Khanty. Not in iso639 lib.
+    "kca": "Khanty",
+    # Ket. Not in iso639 lib.
+    "ket": "Ket",
+    # Komi-Permyak. Not in iso639 lib.
+    "koi": "Komi-Permyak",
+    # Komi-Zyrian. Not in iso639 lib.
+    "kpv": "Komi-Zyrian",
 }

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -252,60 +252,89 @@ LANGUAGE_CODES = {
     "tetelcingo nahuatl": "Tetelcingo Nahuatl",
     # Bouyei. ISO 639-3 only.
     "pcc": "Bouyei",
+    "bouyei": "Bouyei",
     # Lamboya. ISO 639-3 only.
     "lmy": "Laboya",
+    "laboya": "Laboya",
     # Moroccan Arabic. ISO 639-3 only.
     "ary": "Moroccan Arabic",
+    "moroccan arabic": "Moroccan Arabic",
     # Mandarin Chinese. ISO 639-3 only.
     "cmn": "Chinese",
+    "chinese": "Chinese",
     # Abkhaz. Would be Abkhazian in ISO 639.
     "abk": "Abkhaz",
+    "abkhaz": "Abkhaz",
     # Avar. Would be Avaric in ISO 639.
     "ava": "Avar",
+    "avar": "Avar",
     # Buryat. Would be Buriat in ISO 639.
     "bua": "Buryat",
+    "buryat": "Buryat",
     # Chukchi. Would be Chukot in ISO 639.
     "ckt": "Chukchi",
+    "chukchi": "Chukchi",
     # Burushaski. ISO 639-3 only.
     "bsk": "Burushaski",
+    "burushaski": "Burushaski",
     # Evenki. Not in iso639 lib.
     "evn": "Evenki",
+    "evenki": "Evenki",
     # Southern Yukaghir. Not in iso639 lib.
     "yux": "Southern Yukaghir",
+    "southern yukaghir": "Southern Yukaghir",
     # Tundra Nenets. Not in iso639 lib.
     "yrk": "Tundra Nenets",
+    "tundra nenets": "Tundra Nenets",
     # Estonian. Not in iso639 lib.
     "ekk": "Estonian",
+    "estonian": "Estonian",
     # Livvi. Not in iso639 lib.
     "olo": "Livvi",
+    "livvi": "Livvi",
     # Kildin Sami. Not in iso639 lib.
     "sjd": "Kildin Sami",
+    "kildin sami": "Kildin Sami",
     # Northern Yukaghir. Not in iso639 lib.
     "ykg": "Northern Yukaghir",
+    "northern yukaghir": "Northern Yukaghir",
     # Nanai. Not in iso639 lib.
     "gld": "Nanai",
+    "nanai": "Nanai",
     # Persian. Not in iso639 lib.
     "pes": "Persian",
+    "persian": "Persian",
     # Greenlandic. Would be Kalaallisut in ISO 639.
     "kal": "Greenlandic",
+    "greenlandic": "Greenlandic",
     # Khanty. Not in iso639 lib.
     "kca": "Khanty",
+    "khanty": "Khanty",
     # Ket. Not in iso639 lib.
+    "ket": "Ket",
     "ket": "Ket",
     # Komi-Permyak. Not in iso639 lib.
     "koi": "Komi-Permyak",
+    "komi-permyak": "Komi-Permyak",
     # Komi-Zyrian. Not in iso639 lib.
     "kpv": "Komi-Zyrian",
+    "komi-zyrian": "Komi-Zyrian",
     # Lak. Not in iso639 lib.
     "lbe": "Lak",
+    "lak": "Lak",
     # Lezgi. Would be Lezghian in ISO 639.
     "lez": "Lezgi",
+    "lezgi": "Lezgi",
     # Eastern Mari. Not in iso639 lib.
     "mhr": "Eastern Mari",
+    "eastern mari": "Eastern Mari",
     # Mansi. Not in iso639 lib.
     "mns": "Mansi",
+    "mansi": "Mansi",
     # Nganasan. Not in iso639 lib.
     "nio": "Nganasan",
+    "nganasan": "Nganasan",
     # Nivkh. Not in iso639 lib.
     "niv": "Nivkh",
+    "nivkh": "Nivkh",
 }

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -268,6 +268,12 @@ LANGUAGE_CODES = {
     "ckt": "Chukchi",
     # Burushaski. ISO 639-3 only.
     "bsk": "Burushaski",
-    # Galician. Not in iso639.
+    # Galician. Not in iso639 lib.
     "glc": "Galician",
+    # Evenki. Not in iso639 lib.
+    "evn": "Evenki",
+    # Southern Yukaghir. Not in iso639 lib.
+    "yux": "Southern Yukaghir",
+    # Tundra Nenets. Not in iso639 lib.
+    "yrk": "Tundra Nenets",
 }

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -257,5 +257,7 @@ LANGUAGE_CODES = {
     # Moroccan Arabic. ISO 639-3 only.
     "ary": "Moroccan Arabic",
     # Mandarin Chinese. ISO 639-3 only.
-    "cmn": "Chinese"
+    "cmn": "Chinese",
+    # Abkhaz. Would be Abkhazian in ISO 639.
+    "abk": "Abkhaz"
 }

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -268,4 +268,6 @@ LANGUAGE_CODES = {
     "ckt": "Chukchi",
     # Burushaski. ISO 639-3 only.
     "bsk": "Burushaski",
+    # Galician. Not in iso639.
+    "glc": "Galician",
 }

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -266,4 +266,6 @@ LANGUAGE_CODES = {
     "bua": "Buryat",
     # Chukchi. Would be Chukot in ISO 639.
     "ckt": "Chukchi",
+    # Burushaski. ISO 639-3 only.
+    "bsk": "Burushaski",
 }

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -312,7 +312,6 @@ LANGUAGE_CODES = {
     "khanty": "Khanty",
     # Ket. Not in iso639 lib.
     "ket": "Ket",
-    "ket": "Ket",
     # Komi-Permyak. Not in iso639 lib.
     "koi": "Komi-Permyak",
     "komi-permyak": "Komi-Permyak",


### PR DESCRIPTION
This PR adds new language codes to the dictionary in `wikipron/languagecodes.py` to increase language coverage.