### PR TITLE
Adds --no-skip-spaces-ortho and --no-skip-spaces-pron flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Unreleased
 
 ### Added
 
--   Added `--no-skip-spaces-ortho` and `--no-skip-spaces-pron` flag. 
+-   Added `--no-skip-spaces-ortho` and `--no-skip-spaces-pron` flag. (\#135)
 -   Logs dialect configuration if specified (\#133).
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ Unreleased
 
 ### Added
 
--   Added `--no-skip-spaces-ortho` and `--no-skip-spaces-pron` flag. (\#135)
+-   Added `--no-skip-spaces-word` and `--no-skip-spaces-pron` flag. (\#135)
 -   Logs dialect configuration if specified (\#133).
 
 ### Deprecated

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ Unreleased
 
 ### Added
 
+-   Added `--no-skip-spaces-ortho` and `--no-skip-spaces-pron` flag. 
 -   Logs dialect configuration if specified (\#133).
 
 ### Deprecated

--- a/languages/wikipron/src/languages.json
+++ b/languages/wikipron/src/languages.json
@@ -794,7 +794,8 @@
         "iso639_name": "Persian",
         "wiktionary_name": "Persian",
         "wiktionary_code": "fa",
-        "casefold": false
+        "casefold": false,
+        "no_skip_spaces_pron": true
     },
     "pms": {
         "iso639_name": "Piemontese",
@@ -986,7 +987,8 @@
         "iso639_name": "Tibetan",
         "wiktionary_name": "Tibetan",
         "wiktionary_code": "bo",
-        "casefold": false
+        "casefold": false,
+        "no_skip_spaces_pron": true
     },
     "ton": {
         "iso639_name": "Tonga (Tonga Islands)",

--- a/languages/wikipron/src/languages.json
+++ b/languages/wikipron/src/languages.json
@@ -177,6 +177,7 @@
         "wiktionary_name": "Chinese",
         "wiktionary_code": "zh",
         "casefold": false,
+        "no_skip_spaces_pron": true,
         "script": {
             "hani": "Han"
         }
@@ -1028,6 +1029,8 @@
         "wiktionary_name": "Vietnamese",
         "wiktionary_code": "vi",
         "casefold": true,
+        "no_skip_spaces_ortho": true,
+        "no_skip_spaces_pron": true,
         "dialect": {
             "hanoi": "Hà Nội",
             "hcmc": "Hồ Chí Minh City",

--- a/languages/wikipron/src/languages.json
+++ b/languages/wikipron/src/languages.json
@@ -1031,7 +1031,7 @@
         "wiktionary_name": "Vietnamese",
         "wiktionary_code": "vi",
         "casefold": true,
-        "no_skip_spaces_ortho": true,
+        "no_skip_spaces_word": true,
         "no_skip_spaces_pron": true,
         "dialect": {
             "hanoi": "Hà Nội",

--- a/languages/wikipron/src/scrape.py
+++ b/languages/wikipron/src/scrape.py
@@ -62,17 +62,15 @@ def main():
         languages = json.load(source)
     # "2020-01-15" (Big Scrape 3)
     cut_off_date = datetime.date.today().isoformat()
+    valid_keys = ["casefold", "no_skip_spaces_pron", "no_skip_spaces_ortho", "dialect"]
     for iso639_code in languages:
-        # config_settings = {
-        #     "key": iso639_code,
-        #     "casefold": languages[iso639_code]["casefold"],
-        #     "no_stress": True,
-        #     "no_syllable_boundaries": True,
-        #     "cut_off_date": cut_off_date,
-        # }
+        wikipron_accepted_settings = {valid_key: languages[iso639_code][valid_key] for valid_key in valid_keys if valid_key in languages[iso639_code]}
         config_settings = {
-            **languages[iso639_code],
+            "key": iso639_code,
+            "no_stress": True,
+            "no_syllable_boundaries": True,
             "cut_off_date": cut_off_date,
+            **wikipron_accepted_settings
         }
         if "dialect" not in languages[iso639_code]:
             _build_scraping_config(

--- a/languages/wikipron/src/scrape.py
+++ b/languages/wikipron/src/scrape.py
@@ -43,9 +43,7 @@ def _call_scrape(lang_settings, config, tsv_path):
     os.remove(tsv_path)
 
 
-def _build_scraping_config(
-    config_settings, wiki_name, dialect_suffix=""
-):
+def _build_scraping_config(config_settings, wiki_name, dialect_suffix=""):
     path_affix = f'../tsv/{config_settings["key"]}_{dialect_suffix}'
 
     phonemic_config = wikipron.Config(**config_settings)
@@ -62,15 +60,19 @@ def main():
         languages = json.load(source)
     # "2020-01-15" (Big Scrape 3)
     cut_off_date = datetime.date.today().isoformat()
-    valid_keys = ["casefold", "no_skip_spaces_pron", "no_skip_spaces_ortho", "dialect"]
+    valid_keys = ["casefold", "no_skip_spaces_pron", "no_skip_spaces_ortho"]
     for iso639_code in languages:
-        wikipron_accepted_settings = {valid_key: languages[iso639_code][valid_key] for valid_key in valid_keys if valid_key in languages[iso639_code]}
+        wikipron_accepted_settings = {
+            valid_key: languages[iso639_code][valid_key]
+            for valid_key in valid_keys
+            if valid_key in languages[iso639_code]
+        }
         config_settings = {
             "key": iso639_code,
             "no_stress": True,
             "no_syllable_boundaries": True,
             "cut_off_date": cut_off_date,
-            **wikipron_accepted_settings
+            **wikipron_accepted_settings,
         }
         if "dialect" not in languages[iso639_code]:
             _build_scraping_config(
@@ -80,7 +82,6 @@ def main():
             for (dialect_key, dialect_value) in languages[iso639_code][
                 "dialect"
             ].items():
-                # Overwrite dialect list if present
                 config_settings["dialect"] = dialect_value
                 _build_scraping_config(
                     config_settings,

--- a/languages/wikipron/src/scrape.py
+++ b/languages/wikipron/src/scrape.py
@@ -60,13 +60,17 @@ def main():
         languages = json.load(source)
     # "2020-01-15" (Big Scrape 3)
     cut_off_date = datetime.date.today().isoformat()
-    valid_keys = ["casefold", "no_skip_spaces_pron", "no_skip_spaces_ortho"]
+    wikipron_accepted_settings = {
+        "casefold": False,
+        "no_skip_spaces_pron": False,
+        "no_skip_spaces_word": False,
+    }
+
     for iso639_code in languages:
-        wikipron_accepted_settings = {
-            valid_key: languages[iso639_code][valid_key]
-            for valid_key in valid_keys
-            if valid_key in languages[iso639_code]
-        }
+        language_settings = languages[iso639_code]
+        for k, v in language_settings.items():
+            if k in wikipron_accepted_settings:
+                wikipron_accepted_settings[k] = v
         config_settings = {
             "key": iso639_code,
             "no_stress": True,
@@ -74,18 +78,18 @@ def main():
             "cut_off_date": cut_off_date,
             **wikipron_accepted_settings,
         }
-        if "dialect" not in languages[iso639_code]:
+        if "dialect" not in language_settings:
             _build_scraping_config(
-                config_settings, languages[iso639_code]["wiktionary_name"]
+                config_settings, language_settings["wiktionary_name"]
             )
         else:
-            for (dialect_key, dialect_value) in languages[iso639_code][
+            for (dialect_key, dialect_value) in language_settings[
                 "dialect"
             ].items():
                 config_settings["dialect"] = dialect_value
                 _build_scraping_config(
                     config_settings,
-                    languages[iso639_code]["wiktionary_name"],
+                    language_settings["wiktionary_name"],
                     dialect_key + "_",
                 )
 

--- a/languages/wikipron/src/scrape.py
+++ b/languages/wikipron/src/scrape.py
@@ -63,11 +63,15 @@ def main():
     # "2020-01-15" (Big Scrape 3)
     cut_off_date = datetime.date.today().isoformat()
     for iso639_code in languages:
+        # config_settings = {
+        #     "key": iso639_code,
+        #     "casefold": languages[iso639_code]["casefold"],
+        #     "no_stress": True,
+        #     "no_syllable_boundaries": True,
+        #     "cut_off_date": cut_off_date,
+        # }
         config_settings = {
-            "key": iso639_code,
-            "casefold": languages[iso639_code]["casefold"],
-            "no_stress": True,
-            "no_syllable_boundaries": True,
+            **languages[iso639_code],
             "cut_off_date": cut_off_date,
         }
         if "dialect" not in languages[iso639_code]:
@@ -78,6 +82,7 @@ def main():
             for (dialect_key, dialect_value) in languages[iso639_code][
                 "dialect"
             ].items():
+                # Overwrite dialect list if present
                 config_settings["dialect"] = dialect_value
                 _build_scraping_config(
                     config_settings,

--- a/tests/test_extract.py
+++ b/tests/test_extract.py
@@ -25,15 +25,17 @@ def test_extraction_functions_have_the_same_signature(func):
 
 
 @pytest.mark.parametrize(
-    "pron, iso639_key, expected",
+    "pron, iso639_key, no_skip_spaces, expected",
     [
-        ("əbzɝvɚ", "eng", False),
+        ("əbzɝvɚ", "eng", False, False),
         # GH-105: Dashed prons are skipped.
-        ("ɑb-", "eng", True),
+        ("ɑb-", "eng", False, True),
         # Spaces in Chinese prons are not skipped.
-        ("ɕjɛ tu", "cmn", False)
+        ("ɕjɛ tu", "cmn", True, False),
+        # Non-breaking spaces are not skipped.
+        ("zinda ɡi", "per", True, False),
     ],
 )
-def test__skip_pron(pron, iso639_key, expected):
-    config = config_factory(key=iso639_key)
+def test__skip_pron(pron, iso639_key, no_skip_spaces, expected):
+    config = config_factory(key=iso639_key, no_skip_spaces_pron=no_skip_spaces)
     assert _skip_pron(pron, config) == expected

--- a/tests/test_scrape.py
+++ b/tests/test_scrape.py
@@ -69,18 +69,20 @@ def test_special_languages_covered_by_smoke_test():
 
 
 @pytest.mark.parametrize(
-    "word, expected",
+    "word, no_skip_spaces, expected",
     [
-        ("foobar", False),
-        ("a phrase", True),
-        ("hyphen-ated", True),
-        ("prefix-", True),
-        ("-suffix", True),
-        ("hasdigit2", True),
+        ("foobar", False, False),
+        ("a phrase", False, True),
+        ("hyphen-ated", False, True),
+        ("prefix-", False, True),
+        ("-suffix", False, True),
+        ("hasdigit2", False, True),
+        ("a phrase", True, False),
+        ("foobar", True, False),
     ],
 )
-def test__skip_word(word, expected):
-    assert _skip_word(word) == expected
+def test__skip_word(word, no_skip_spaces, expected):
+    assert _skip_word(word, no_skip_spaces) == expected
 
 
 @pytest.mark.parametrize(

--- a/wikipron/cli.py
+++ b/wikipron/cli.py
@@ -77,16 +77,12 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--no-skip-spaces-ortho",
         action="store_true",
-        help=(
-            "Skip spaces in the orthography",
-        ),
+        help="Skip spaces in the orthography",
     )
     parser.add_argument(
         "--no-skip-spaces-pron",
         action="store_true",
-        help=(
-            "Skip spaces in the transcription",
-        ),
+        help="Skip spaces in the transcription",
     )
     return parser.parse_args(args)
 
@@ -101,5 +97,6 @@ def _scrape_and_write(config: Config) -> None:
 def main() -> None:
     logging.basicConfig(format="%(levelname)s: %(message)s", level="INFO")
     args = _get_cli_args(sys.argv[1:])
+    print(args)
     config = Config(**args.__dict__)
     _scrape_and_write(config)

--- a/wikipron/cli.py
+++ b/wikipron/cli.py
@@ -74,6 +74,20 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
             "To disable such IPA segmentation, apply this flag."
         ),
     )
+    parser.add_argument(
+        "--no-skip-spaces-ortho",
+        action="store_true",
+        help=(
+            "Skip spaces in the orthography",
+        ),
+    )
+    parser.add_argument(
+        "--no-skip-spaces-pron",
+        action="store_true",
+        help=(
+            "Skip spaces in the transcription",
+        ),
+    )
     return parser.parse_args(args)
 
 

--- a/wikipron/cli.py
+++ b/wikipron/cli.py
@@ -97,6 +97,5 @@ def _scrape_and_write(config: Config) -> None:
 def main() -> None:
     logging.basicConfig(format="%(levelname)s: %(message)s", level="INFO")
     args = _get_cli_args(sys.argv[1:])
-    print(args)
     config = Config(**args.__dict__)
     _scrape_and_write(config)

--- a/wikipron/cli.py
+++ b/wikipron/cli.py
@@ -75,7 +75,7 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--no-skip-spaces-ortho",
+        "--no-skip-spaces-word",
         action="store_true",
         help="Skip spaces in the orthography",
     )

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -57,6 +57,8 @@ class Config:
         phonetic: bool = False,
         dialect: Optional[str] = None,
         no_segment: bool = False,
+        no_skip_spaces_ortho: bool = False,
+        no_skip_spaces_pron: bool = False,
     ):
         self.language: str = self._get_language(key)
         self.casefold: Callable[[Word], Word] = self._get_casefold(casefold)
@@ -71,6 +73,8 @@ class Config:
         self.extract_word_pron: ExtractFunc = self._get_extract_word_pron(
             self.language
         )
+        self.no_skip_spaces_ortho = no_skip_spaces_ortho
+        self.no_skip_spaces_pron = no_skip_spaces_pron
 
     def _get_language(self, key) -> str:
         key = key.lower().strip()

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -73,8 +73,8 @@ class Config:
         self.extract_word_pron: ExtractFunc = self._get_extract_word_pron(
             self.language
         )
-        self.no_skip_spaces_ortho = no_skip_spaces_ortho
-        self.no_skip_spaces_pron = no_skip_spaces_pron
+        self.no_skip_spaces_ortho: bool = no_skip_spaces_ortho
+        self.no_skip_spaces_pron: bool = no_skip_spaces_pron
 
     def _get_language(self, key) -> str:
         key = key.lower().strip()

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -57,7 +57,7 @@ class Config:
         phonetic: bool = False,
         dialect: Optional[str] = None,
         no_segment: bool = False,
-        no_skip_spaces_ortho: bool = False,
+        no_skip_spaces_word: bool = False,
         no_skip_spaces_pron: bool = False,
     ):
         self.language: str = self._get_language(key)
@@ -73,7 +73,7 @@ class Config:
         self.extract_word_pron: ExtractFunc = self._get_extract_word_pron(
             self.language
         )
-        self.no_skip_spaces_ortho: bool = no_skip_spaces_ortho
+        self.no_skip_spaces_word: bool = no_skip_spaces_word
         self.no_skip_spaces_pron: bool = no_skip_spaces_pron
 
     def _get_language(self, key) -> str:

--- a/wikipron/extract/core.py
+++ b/wikipron/extract/core.py
@@ -15,7 +15,7 @@ if typing.TYPE_CHECKING:
 def _skip_pron(pron: str, config: "Config") -> bool:
     if "-" in pron:
         return True
-    if " " in pron and not config.no_skip_spaces_pron:
+    if (" " in pron or "\u00A0" in pron) and not config.no_skip_spaces_pron:
         return True
     return False
 
@@ -45,9 +45,6 @@ def yield_pron(
             continue
         if pron:
             # The segments package inserts a # in-between spaces.
-            # Should # just be replaced with a " "? As currently written
-            # there is no way to distinguish between transcriptions of words
-            # with and without spaces. Perhaps it is best to just keep the #?
             if config.no_skip_spaces_pron:
                 pron = pron.replace(" #", "")
             yield pron

--- a/wikipron/extract/core.py
+++ b/wikipron/extract/core.py
@@ -15,7 +15,7 @@ if typing.TYPE_CHECKING:
 def _skip_pron(pron: str, config: "Config") -> bool:
     if "-" in pron:
         return True
-    if " " in pron and config.language != "Chinese":
+    if " " in pron and not config.no_skip_spaces_pron:
         return True
     return False
 
@@ -44,7 +44,10 @@ def yield_pron(
             )
             continue
         if pron:
-            # The segments package inserts a # in between spaces.
-            if config.language == "Chinese":
+            # The segments package inserts a # in-between spaces.
+            # Should # just be replaced with a " "? As currently written
+            # there is no way to distinguish between transcriptions of words
+            # with and without spaces. Perhaps it is best to just keep the #?
+            if config.no_skip_spaces_pron:
                 pron = pron.replace(" #", "")
             yield pron

--- a/wikipron/extract/core.py
+++ b/wikipron/extract/core.py
@@ -15,7 +15,7 @@ if typing.TYPE_CHECKING:
 def _skip_pron(pron: str, config: "Config") -> bool:
     if "-" in pron:
         return True
-    if (" " in pron or "\u00A0" in pron) and not config.no_skip_spaces_pron:
+    if not config.no_skip_spaces_pron and (" " in pron or "\u00A0" in pron):
         return True
     return False
 

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -16,7 +16,7 @@ _PAGE_TEMPLATE = "https://en.wiktionary.org/wiki/{word}"
 
 def _skip_word(word: str, no_skip_spaces: bool) -> bool:
     # Skips multiword examples.
-    if (" " in word or "\u00A0" in word) and not no_skip_spaces:
+    if not no_skip_spaces and (" " in word or "\u00A0" in word):
         return True
     # Skips examples containing a dash.
     if "-" in word:
@@ -36,7 +36,7 @@ def _scrape_once(data, config: Config) -> Iterator[WordPronPair]:
     for member in data["query"]["categorymembers"]:
         word = member["title"]
         date = member["timestamp"]
-        if _skip_word(word, config.no_skip_spaces_ortho) or _skip_date(
+        if _skip_word(word, config.no_skip_spaces_word) or _skip_date(
             date, config.cut_off_date
         ):
             continue

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -16,7 +16,7 @@ _PAGE_TEMPLATE = "https://en.wiktionary.org/wiki/{word}"
 
 def _skip_word(word: str, no_skip_spaces: bool) -> bool:
     # Skips multiword examples.
-    if " " in word and not no_skip_spaces:
+    if (" " in word or "\u00A0" in word) and not no_skip_spaces:
         return True
     # Skips examples containing a dash.
     if "-" in word:

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -14,9 +14,9 @@ _CATEGORY_TEMPLATE = "Category:{language} terms with IPA pronunciation"
 _PAGE_TEMPLATE = "https://en.wiktionary.org/wiki/{word}"
 
 
-def _skip_word(word: str) -> bool:
+def _skip_word(word: str, no_skip_spaces: bool) -> bool:
     # Skips multiword examples.
-    if " " in word:
+    if " " in word and not no_skip_spaces:
         return True
     # Skips examples containing a dash.
     if "-" in word:
@@ -36,7 +36,7 @@ def _scrape_once(data, config: Config) -> Iterator[WordPronPair]:
     for member in data["query"]["categorymembers"]:
         word = member["title"]
         date = member["timestamp"]
-        if _skip_word(word) or _skip_date(date, config.cut_off_date):
+        if _skip_word(word, config.no_skip_spaces_ortho) or _skip_date(date, config.cut_off_date):
             continue
         request = session.get(_PAGE_TEMPLATE.format(word=word), timeout=10)
         for word, pron in config.extract_word_pron(word, request, config):

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -36,7 +36,9 @@ def _scrape_once(data, config: Config) -> Iterator[WordPronPair]:
     for member in data["query"]["categorymembers"]:
         word = member["title"]
         date = member["timestamp"]
-        if _skip_word(word, config.no_skip_spaces_ortho) or _skip_date(date, config.cut_off_date):
+        if _skip_word(word, config.no_skip_spaces_ortho) or _skip_date(
+            date, config.cut_off_date
+        ):
             continue
         request = session.get(_PAGE_TEMPLATE.format(word=word), timeout=10)
         for word, pron in config.extract_word_pron(word, request, config):


### PR DESCRIPTION
- [X] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.

`--no-skip-spaces-ortho` when set to True will not skip words that contain spaces (whether regular or non-breaking  - though I haven't come across any of these yet). This required modifying `cli.py`, `config.py`, and `wikipron/scrape.py`
`--no-skip-spaces-pron` when set to True will not skip transcriptions that contain spaces (whether regular or non-breaking). This required modifying `cli.py`, `config.py`, and `extract/core.py`. `extract/core.py` now also checks whether this flag is set and removes the `"#"` that the `segments` package inserts. (Is this the desired behavior discussed in #133?)

I also modified `languages.json` to include the appropriate flags for the relevant languages (Chinese, Vietnamese, Persian, Tibetan). `src/scrape.py` was slightly modified to make it easier to build the config dictionary passed to Wikipron. 
(It's my first time adding a flag so, though this seems to work, I'm not entirely sure I followed best practices, in particular for modifying `config.py`.)