### PR TITLE
Remove Persian from language code map

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,9 +12,10 @@ Unreleased
 
 ### Added
 
--   Logs dialect configuration if specified (\#133).
+-   Handled additional language codes. (\#132, \#148)
+-   Logged dialect configuration if specified. (\#133)
 -   Added `--no-skip-spaces-word` and `--no-skip-spaces-pron` flag. (\#135)
--   Adds typing to big scrape code. (\#140)
+-   Added typing to big scrape code. (\#140)
 
 ### Deprecated
 ### Removed

--- a/wikipron/languagecodes.py
+++ b/wikipron/languagecodes.py
@@ -301,9 +301,6 @@ LANGUAGE_CODES = {
     # Nanai. Not in iso639 lib.
     "gld": "Nanai",
     "nanai": "Nanai",
-    # Persian. Not in iso639 lib.
-    "pes": "Persian",
-    "persian": "Persian",
     # Greenlandic. Would be Kalaallisut in ISO 639.
     "kal": "Greenlandic",
     "greenlandic": "Greenlandic",


### PR DESCRIPTION
As a follow-up of https://github.com/kylebgorman/wikipron/pull/132#discussion_r409368166, I'm removing Persian from `languagecodes.py`. The "iso639" package already resolves "per" and "fas" (both of which are ISO 639-2 codes) to "Persian".

The code "pes" is ISO 639-3 only, and is for "Iranian Persian" specifically. It looks like Wiktionary entries for Persian have "Iranian Persian" as a dialect label (e.g., [this entry](https://en.wiktionary.org/wiki/%D8%A2%D9%84%D9%88%D8%AF%DA%AF%DB%8C#Persian)). So if a WikiPron user would like to target "Iranian Persian" specifically, they can specify the dialect flag for that.