### PR TITLE
Whitelist cleanup

### DIFF
--- a/data/wikipron/README.md
+++ b/data/wikipron/README.md
@@ -102,7 +102,7 @@
 | [TSV](tsv/kor_phonetic.tsv) | kor | Korean | Korean | False | Phonetic | 12,830 |
 | [TSV](tsv/kur_phonemic.tsv) | kur | Kurdish | Kurdish | True | Phonemic | 1,153 |
 | [TSV](tsv/lao_phonemic.tsv) | lao | Lao | Lao | False | Phonemic | 301 |
-| [TSV](tsv/lat_phonemic.tsv) | lat | Latin | Latin | True | Phonemic | 34,373 |
+| [TSV](tsv/lat_phonemic.tsv) | lat | Latin | Latin | True | Phonemic | 34,181 |
 | [TSV](tsv/lat_phonetic.tsv) | lat | Latin | Latin | True | Phonetic | 33,782 |
 | [TSV](tsv/lav_phonetic.tsv) | lav | Latvian | Latvian | True | Phonetic | 1,272 |
 | [TSV](tsv/ayl_phonemic.tsv) | ayl | Libyan Arabic | Libyan Arabic | False | Phonemic | 153 |

--- a/data/wikipron/languages_summary.tsv
+++ b/data/wikipron/languages_summary.tsv
@@ -100,7 +100,7 @@ kik_phonemic.tsv	kik	Kikuyu	Kikuyu	True	Phonemic	1095
 kor_phonetic.tsv	kor	Korean	Korean	False	Phonetic	12830
 kur_phonemic.tsv	kur	Kurdish	Kurdish	True	Phonemic	1153
 lao_phonemic.tsv	lao	Lao	Lao	False	Phonemic	301
-lat_phonemic.tsv	lat	Latin	Latin	True	Phonemic	34373
+lat_phonemic.tsv	lat	Latin	Latin	True	Phonemic	34181
 lat_phonetic.tsv	lat	Latin	Latin	True	Phonetic	33782
 lav_phonetic.tsv	lav	Latvian	Latvian	True	Phonetic	1272
 ayl_phonemic.tsv	ayl	Libyan Arabic	Libyan Arabic	False	Phonemic	153

--- a/data/wikipron/src/generate_summary.py
+++ b/data/wikipron/src/generate_summary.py
@@ -98,16 +98,10 @@ def main() -> None:
             "| :---- | :----: | :----: | :----: | :----: | :----: | ----: |",
             file=sink,
         )
-<<<<<<< HEAD
-        for link, code, n1, n2, cf, ph, count in readme_list:
-            print(
-                f"| {link} | {code} | {n1} | {n2} | {cf} | {ph} | {count:,} |",
-=======
         for link, code, iso_name, wiki_name, cf, ph, count in readme_list:
             print(
                 f"| {link} | {code} | {iso_name} | {wiki_name} | {cf} | {ph} "
                 f"| {count:,} |",
->>>>>>> f2034e2c2e44112acb70c0f3438597596b65ae21
                 file=sink,
             )
 

--- a/data/wikipron/src/postprocess
+++ b/data/wikipron/src/postprocess
@@ -1,13 +1,27 @@
 #!/bin/bash
 set -eou pipefail
 
-for TSV in ../tsv/*.tsv; do
-    # Explicitly uses byte-wise comparison for sorting
-    # rather than a locale-dependent comparison.
-    LC_ALL=C sort -u -o "${TSV}" "${TSV}"
-    ./generalized_split.py "${TSV}"
-done
+split() {
+    for TSV in ../tsv/*.tsv; do
+        # Explicitly uses byte-wise comparison for sorting
+        # rather than a locale-dependent comparison.
+        LC_ALL=C sort -u -o "${TSV}" "${TSV}"
+        ./generalized_split.py "${TSV}"
+    done
+}
 
-./whitelist.py ../tsv/eng_uk_phonemic.tsv ../whitelist/eng_uk_phonemic.whitelist ../tsv/eng_uk_phonemic.tsv
-./whitelist.py ../tsv/eng_us_phonemic.tsv ../whitelist/eng_us_phonemic.whitelist ../tsv/eng_us_phonemic.tsv
-./whitelist.py ../tsv/lat_phonemic.tsv ../whitelist/lat_phonemic.whitelist ../tsv/lat_filtered_phonemic.tsv
+whitelist() {
+    for WHITELIST in ../whitelist/*.whitelist; do
+        INPUT_TSV="${WHITELIST//whitelist/tsv}"
+        OUTPUT_TSV=$(mktemp -t)
+        ./whitelist.py "${INPUT_TSV}" "${WHITELIST}" "${OUTPUT_TSV}" 2>/dev/null
+        mv "${OUTPUT_TSV}" "${INPUT_TSV}"
+    done
+}
+
+main() {
+    time split
+    time whitelist
+}
+
+main

--- a/data/wikipron/src/postprocess
+++ b/data/wikipron/src/postprocess
@@ -14,7 +14,8 @@ whitelist() {
     for WHITELIST in ../whitelist/*.whitelist; do
         INPUT_TSV="${WHITELIST//whitelist/tsv}"
         OUTPUT_TSV=$(mktemp -t)
-        ./whitelist.py "${INPUT_TSV}" "${WHITELIST}" "${OUTPUT_TSV}" 2>/dev/null
+        # TODO: Redirect these reports somewhere sensible.
+        ./whitelist.py "${INPUT_TSV}" "${WHITELIST}" "${OUTPUT_TSV}"
         mv "${OUTPUT_TSV}" "${INPUT_TSV}"
     done
 }

--- a/data/wikipron/tsv/lat_phonemic.tsv
+++ b/data/wikipron/tsv/lat_phonemic.tsv
@@ -1,32 +1,23 @@
 *abanteō	a b a n t e oː	0
-*abanteō	a β a n t e oː	0
 *abbatuō	a b b a t u oː	0
-*abbatuō	a β β a t u oː	0
 *abbatō	a b b a t oː	0
-*abbatō	a β β a t oː	0
 *abbiberō	a b b i b e r oː	0
-*abbiberō	a β β i β e r oː	0
 *absedium	a p s e d i u m	0
 *absedium	a p s ɛ d i u m	0
 *absediī	a p s e d i iː	0
 *absediī	a p s ɛ d i iː	0
 *abyssimus	a b y s s i m u s	0
-*abyssimus	a β e s s i m u s	0
 *acca	a k k a	0
 *accaptiō	a k k a p t i oː	0
 *accaptō	a k k a p t oː	0
 *accapō	a k k a p oː	0
 *accognitō	a k k o ɡ n i t oː	0
-*accognitō	a k k ɔ ɡ n i t oː	0
 *accolligō	a k k o l l i ɡ oː	0
-*accolligō	a k k ɔ l l i ɡ oː	0
 *accollō	a k k o l l oː	0
-*accollō	a k k ɔ l l oː	0
 *accomplēscō	a k k o m p l eː s k oː	0
 *accomplīre	a k k o m p l iː r e	0
 *accordāre	a k k o r d aː r e	0
 *accordō	a k k o r d oː	0
-*accordō	a k k ɔ r d oː	0
 *accum	a k k u m	0
 *acquaeriō	a k kʷ a e̯ r i oː	0
 *acquaeriō	a k kʷ e r i oː	0
@@ -38,13 +29,9 @@
 *acūtiāre	a k uː t i aː r e	0
 *acūtiō	a k uː t i oː	0
 *adbassiāre	a d b a s s i aː r e	0
-*adbassiāre	a d β a s s i aː r e	0
 *adbassiō	a b b a s s i oː	0
-*adbassiō	a β β a s s i oː	0
 *adbellēscō	a d b e l l eː s k oː	0
-*adbellēscō	a d β e l l eː s k oː	0
 *adbracchiō	a d b r a k kʰ i oː	0
-*adbracchiō	a d β r a k kʰ i oː	0
 *adiuxtāre	a d j u k s t aː r e	0
 *adiuxtāre	a d j u s t aː r e	0
 *adiuxtō	a d j u k s t oː	0
@@ -63,15 +50,10 @@
 *adpressum	a p p r ɛ s s u m	0
 *adpācāre	a t p aː k aː r e	0
 *adventūra	a d w e n t uː r a	0
-*adventūra	a d β e n t uː r a	0
 *advitiāre	a d w i t i aː r e	0
-*advitiāre	a d β i t i aː r e	0
 *advitiō	a d w i t i oː	0
-*advitiō	a d β i t i oː	0
 *advērāre	a d w eː r aː r e	0
-*advērāre	a d β eː r aː r e	0
 *advērō	a d w eː r oː	0
-*advērō	a d β eː r oː	0
 *aetāticum	a e̯ t aː t i k u m	0
 *aetāticum	e t aː t i k u m	0
 *aetāticī	a e̯ t aː t i k iː	0
@@ -83,7 +65,6 @@
 *agēscō	a ɡ eː s k oː	0
 *aiūnus	a j j uː n u s	0
 *alemosynē	a l e m o s y n eː	0
-*alemosynē	a l e m ɔ s e n eː	0
 *alicūnus	a l i k uː n u s	0
 *alima	a l i m a	0
 *alisna	a l i s n a	0
@@ -95,11 +76,8 @@
 *altiāre	a l t i aː r e	0
 *altiō	a l t i oː	0
 *alēmosyna	a l eː m o s y n a	0
-*alēmosyna	a l eː m ɔ s e n a	0
 *ambitō	a m b i t oː	0
-*ambitō	a m β i t oː	0
 *ambosta	a m b o s t a	0
-*ambosta	a m β ɔ s t a	0
 *amicitātis	a m i k i t aː t i s	0
 *amāricus	a m aː r i k u s	0
 *amīcitās	a m iː k i t aː s	0
@@ -109,15 +87,11 @@
 *appariculō	a p p a r i k u l oː	0
 *appodiāre	a p p o d i aː r e	0
 *appodiō	a p p o d i oː	0
-*appodiō	a p p ɔ d i oː	0
 *appācāre	a p p aː k aː r e	0
 *appācō	a p p aː k oː	0
 *arbalista	a r b a l i s t a	0
-*arbalista	a r β a l i s t a	0
 *arbalistē	a r b a l i s t eː	0
-*arbalistē	a r β a l i s t eː	0
 *arborus	a r b o r u s	0
-*arborus	a r β o r u s	0
 *arciō	a r k i oː	0
 *arciōnis	a r k i oː n i s	0
 *arrestāre	a r r e s t aː r e	0
@@ -139,67 +113,36 @@
 *ausāre	a u̯ s aː r e	0
 *ausō	a u̯ s oː	0
 *aviola	a w i o l a	0
-*aviola	a β i o l a	0
 *aviolus	a w i o l u s	0
-*aviolus	a β i o l u s	0
 *baba	b a b a	0
-*baba	β a β a	0
 *babbus	b a b b u s	0
-*babbus	β a β β u s	0
 *baccinum	b a k k i n u m	0
-*baccinum	β a k k i n u m	0
 *baiulivi	b a j j u l i w i	0
-*baiulivi	β a j j u l i β i	0
 *baiulīvus	b a j j u l iː w u s	0
-*baiulīvus	β a j j u l iː β u s	0
 *banniō	b a n n i oː	0
-*banniō	β a n n i oː	0
 *bannīre	b a n n iː r e	0
-*bannīre	β a n n iː r e	0
 *barra	b a r r a	0
-*barra	β a r r a	0
 *barrae	b a r r a e̯	0
-*barrae	β a r r e	0
 *barrum	b a r r u m	0
-*barrum	β a r r u m	0
 *bassiāre	b a s s i aː r e	0
-*bassiāre	β a s s i aː r e	0
 *bassiō	b a s s i oː	0
-*bassiō	β a s s i oː	0
 *bastāre	b a s t aː r e	0
-*bastāre	β a s t aː r e	0
 *bastō	b a s t oː	0
-*bastō	β a s t oː	0
 *bataclum	b a t a k l u m	0
-*bataclum	β a t a k l u m	0
 *bellitia	b e l l i t i a	0
-*bellitia	β e l l i t i a	0
 *bellitās	b e l l i t aː s	0
-*bellitās	β ɛ l l i t aː s	0
 *bellitātis	b e l l i t aː t i s	0
-*bellitātis	β e l l i t aː t i s	0
 *bisonium	b i s o n i u m	0
-*bisonium	β i s ɔ n i u m	0
 *blancus	b l a n k u s	0
-*blancus	β l a n k u s	0
 *blastemō	b l a s t e m oː	0
-*blastemō	β l a s t e m oː	0
 *blastimō	b l a s t i m oː	0
-*blastimō	β l a s t i m oː	0
 *blāvus	b l aː w u s	0
-*blāvus	β l aː β u s	0
 *boscāticum	b o s k aː t i k u m	0
-*boscāticum	β o s k aː t i k u m	0
 *bragiō	b r a ɡ i oː	0
-*bragiō	β r a ɡ i oː	0
 *brandus	b r a n d u s	0
-*brandus	β r a n d u s	0
 *brigna	b r i ɡ n a	0
-*brigna	β r i ɡ n a	0
 *bullicāre	b u l l i k aː r e	0
-*bullicāre	β u l l i k aː r e	0
 *bullicō	b u l l i k oː	0
-*bullicō	β u l l i k oː	0
 *cadentia	k a d e n t i a	0
 *cadentia	k a d ɛ n t i a	0
 *cadentiē	k a d e n t i eː	0
@@ -218,27 +161,20 @@
 *casicāre	k a s i k aː r e	0
 *catūnum	k a t uː n u m	0
 *caveola	k a w e o l a	0
-*caveola	k a β ɛ o l a	0
 *cavula	k a w u l a	0
-*cavula	k a β u l a	0
 *cawa	k a w a	0
-*cawa	k a β a	0
 *chīrurgiānus	kʰ iː r u r ɡ i aː n u s	0
 *cinūsia	k i n uː s i a	0
 *clapāre	k l a p aː r e	0
 *clapō	k l a p oː	0
 *clubium	k l u b i u m	0
-*clubium	k l u β i u m	0
 *cnīfus	k n iː f u s	0
 *coacticāre	k o a k t i k a r e	0
 *coacticāre	k o a k t i k aː r e	0
 *cocīnārius	k o k iː n aː r i u s	0
 *colocō	k o l o k oː	0
-*colocō	k ɔ l o k oː	0
 *combattere	k o m b a t t e r e	0
-*combattere	k o m β a t t e r e	0
 *combattō	k o m b a t t oː	0
-*combattō	k o m β a t t oː	0
 *cominitiō	k o m i n i t i oː	0
 *commandāre	k o m m a n d aː r e	0
 *commandō	k o m m a n d oː	0
@@ -247,15 +183,12 @@
 *contingēscō	k o n t i n ɡ eː s k oː	0
 *contrāfaciō	k o n t r aː f a k i oː	0
 *convītāre	k o n w iː t aː r e	0
-*convītāre	k o n β iː t aː r e	0
 *convītō	k o n w iː t oː	0
-*convītō	k o n β iː t oː	0
 *cordārius	k o r d aː r i u s	0
 *corātiō	k o r a t͡s i o	0
 *corātiō	k o r aː t i oː	0
 *corātiōnis	k o r aː t i oː n i s	0
 *crebellum	k r e b e l l u m	0
-*crebellum	k r e β ɛ l l u m	0
 *cremere	k r e m e r e	0
 *cremere	k r ɛ m e r e	0
 *cremō	k r e m oː	0
@@ -275,7 +208,6 @@
 *damnāticum	d a m n aː t i k u m	0
 *danciō	d a n k i oː	0
 *decembrius	d e k e m b r i u s	0
-*decembrius	d e k ɛ m β r i u s	0
 *deintus	d e i n t u s	0
 *delicatiāre	d e l i k a t i aː r e	0
 *delicatiō	d e l i k a t i oː	0
@@ -315,35 +247,25 @@
 *excalceus	e k s k a l k e u s	0
 *excalceus	e s k a l k e u s	0
 *excambiō	e k s k a m b i oː	0
-*excambiō	e s k a m β i oː	0
 *excappō	e k s k a p p oː	0
 *excappō	e s k a p p oː	0
 *excarminō	e k s k a r m i n oː	0
 *excarminō	e s k a r m i n oː	0
 *exfortiō	e k s f o r t i oː	0
-*exfortiō	e s f ɔ r t i oː	0
 *exfridō	e k s f r i d oː	0
 *exfridō	ɛ s f r i d oː	0
 *expaventāre	e k s p a w e n t aː r e	0
-*expaventāre	e s p a β e n t aː r e	0
 *expaventō	e k s p a w e n t oː	0
-*expaventō	e s p a β ɛ n t oː	0
 *experlavō	e k s p e r l a w oː	0
-*experlavō	e s p ɛ r l a β oː	0
 *extorcere	e k s t o r k e r e	0
-*extorcere	e s t ɔ r k e r e	0
 *extorcō	e k s t o r k oː	0
-*extorcō	e s t ɔ r k oː	0
 *extūtāre	e k s t uː t aː r e	0
 *extūtāre	e s t uː t aː r e	0
 *extūtō	e k s t uː t oː	0
 *extūtō	e s t uː t oː	0
 *exventō	e k s w e n t oː	0
-*exventō	e s β ɛ n t oː	0
 *exvolāre	e k s w o l aː r e	0
-*exvolāre	e s β o l aː r e	0
 *exvolō	e k s w o l oː	0
-*exvolō	ɛ s β o l oː	0
 *exēligere	e k s eː l i ɡ e r e	0
 *exēligere	e s eː l i ɡ e r e	0
 *exēligō	e k s eː l i ɡ oː	0
@@ -361,23 +283,18 @@
 *flōtus	f l oː t u s	0
 *focācia	f o k aː k i a	0
 *fortia	f o r t i a	0
-*fortia	f ɔ r t i a	0
 *fortiāre	f o r t i aː r e	0
 *fortiō	f o r t i oː	0
-*fortiō	f ɔ r t i oː	0
 *frappō	f r a p p oː	0
 *frīctūra	f r iː k t uː r a	0
 *frōcus	f r oː k u s	0
 *fābellāre	f aː b e l l aː r e	0
-*fābellāre	f aː β e l l aː r e	0
 *fābellō	f aː b e l l oː	0
-*fābellō	f aː β ɛ l l oː	0
 *fāta	f aː t a	0
 *fēminus	f eː m i n u s	0
 *fēstizō	f eː s t i z z oː	0
 *fētiolus	f eː t i o l u s	0
 *fībella	f iː b e l l a	0
-*fībella	f iː β ɛ l l a	0
 *fīccō	f iː k k oː	0
 *fīgicō	f iː ɡ i k oː	0
 *fīnēscō	f iː n eː s k oː	0
@@ -386,14 +303,11 @@
 *genuclum	ɡ e n u k l u m	0
 *glacia	ɡ l a k i a	0
 *grabō	ɡ r a b oː	0
-*grabō	ɡ r a β oː	0
-*habūtus	a β uː t u s	0
 *habūtus	h a b uː t u s	0
 *halenāre	a l e n aː r e	0
 *halenāre	h a l e n aː r e	0
 *halenō	a l e n oː	0
 *halenō	h a l e n oː	0
-*halsbergus	a l s β ɛ r ɡ u s	0
 *halsbergus	h a l s b e r ɡ u s	0
 *harpa	a r p a	0
 *harpa	h a r p a	0
@@ -407,11 +321,8 @@
 *hōnta	oː n t a	0
 *illu	i l l u	0
 *imbibitō	i m b i b i t oː	0
-*imbibitō	i m β i β i t oː	0
 *imboscāre	i m b o s k aː r e	0
-*imboscāre	i m β o s k aː r e	0
 *imboscō	i m b o s k oː	0
-*imboscō	i m β ɔ s k oː	0
 *impliō	i m p l i oː	0
 *implīre	i m p l iː r e	0
 *imprehendere	i m p r e h e n d e r e	0
@@ -430,20 +341,15 @@
 *indēnsō	i n d e n s oː	0
 *indēnsō	i n d ɛ n s oː	0
 *ingrevicō	i n ɡ r e w i k oː	0
-*ingrevicō	i n ɡ r ɛ β i k oː	0
 *interrō	i n t e r r oː	0
 *interrō	i n t ɛ r r oː	0
 *intorcō	i n t o r k oː	0
-*intorcō	i n t ɔ r k oː	0
 *inuxorō	i n u k s o r oː	0
 *inuxorō	i n u s o r oː	0
 *invirdēscō	i n w i r d eː s k oː	0
-*invirdēscō	i n β i r d eː s k oː	0
 *invitiō	i n w i t i oː	0
-*invitiō	i n β i t i oː	0
 *iocāre	j o k aː r e	0
 *iocō	j o k oː	0
-*iocō	j ɔ k oː	0
 *iugaster	j u ɡ a s t e r	0
 *iānuella	j aː n u e l l a	0
 *iānuella	j aː n u ɛ l l a	0
@@ -454,7 +360,6 @@
 *languīre	l a n ɡʷ iː r e	0
 *lausa	l a u̯ s a	0
 *leviārius	l e w i aː r i u s	0
-*leviārius	l e β i aː r i u s	0
 *linguāticum	l i n ɡʷ aː t i k u m	0
 *longitānus	l o n ɡ i t aː n u s	0
 *lūciō	l uː k i oː	0
@@ -480,16 +385,11 @@
 *montānia	m o n t aː n i a	0
 *montāre	m o n t aː r e	0
 *mordere	m o r d e r e	0
-*mordere	m ɔ r d e r e	0
 *mordō	m o r d oː	0
-*mordō	m ɔ r d oː	0
 *moriō	m o r i oː	0
-*moriō	m ɔ r i oː	0
 *morīre	m o r iː r e	0
 *movere	m o w e r e	0
-*movere	m ɔ β e r e	0
 *movō	m o w oː	0
-*movō	m ɔ β oː	0
 *muccāre	m u k k aː r e	0
 *muccō	m u k k oː	0
 *mulgere	m u l ɡ e r e	0
@@ -510,34 +410,23 @@
 *mētīre	m eː t iː r e	0
 *mūsclus	m uː s k l u s	0
 *nivicāre	n i w i k aː r e	0
-*nivicāre	n i β i k aː r e	0
 *nivicō	n i w i k oː	0
-*nivicō	n i β i k oː	0
 *nivāre	n i w aː r e	0
-*nivāre	n i β aː r e	0
 *nivō	n i w oː	0
-*nivō	n i β oː	0
 *nocō	n o k oː	0
-*nocō	n ɔ k oː	0
 *notō	n o t oː	0
-*notō	n ɔ t oː	0
 *nuō	n u oː	0
 *nōvāgintā	n oː w aː ɡ i n t aː	0
-*nōvāgintā	n oː β aː ɡ i n t aː	0
 *oblītāre	o b l iː t aː r e	0
-*oblītāre	o β l iː t aː r e	0
 *oblītō	o b l iː t oː	0
-*oblītō	o β l iː t oː	0
 *odiāre	o d i aː r e	0
 *odiō	o d i oː	0
-*odiō	ɔ d i oː	0
 *offeriō	o f f e r i oː	0
 *offeriō	o f f ɛ r i oː	0
 *offerēscere	o f f e r eː s k e r e	0
 *offerēscō	o f f e r eː s k oː	0
 *offerīre	o f f e r iː r e	0
 *oleō	o l e oː	0
-*oleō	ɔ l e oː	0
 *orgōlliō	o r ɡ oː l l i oː	0
 *passarus	p a s s a r u s	0
 *passāre	p a s s aː r e	0
@@ -561,21 +450,15 @@
 *piscāre	p i s k aː r e	0
 *piscō	p i s k oː	0
 *plovere	p l o w e r e	0
-*plovere	p l ɔ β e r e	0
 *plovō	p l o w oː	0
-*plovō	p l ɔ β oː	0
 *plōppus	p l oː p p u s	0
 *podiō	p o d i oː	0
-*podiō	p ɔ d i oː	0
 *possō	p o s s oː	0
-*possō	p ɔ s s oː	0
 *postius	p o s t i u s	0
-*postius	p ɔ s t i u s	0
 *precāre	p r e k aː r e	0
 *precō	p r e k oː	0
 *precō	p r ɛ k oː	0
 *prīmavēra	p r iː m a w eː r a	0
-*prīmavēra	p r iː m a β eː r a	0
 *puppa	p u p p a	0
 *putiāre	p u t i aː r e	0
 *putriō	p u t r i oː	0
@@ -595,7 +478,6 @@
 *quassicō	kʷ a s s i k oː	0
 *quōmo	kʷ oː m o	0
 *rabia	r a b i a	0
-*rabia	r a β i a	0
 *ranceō	r a n k e oː	0
 *raspō	r a s p oː	0
 *reexcaptāre	r e e k s k a p t aː r e	0
@@ -615,7 +497,6 @@
 *retina	r e t i n a	0
 *retina	r ɛ t i n a	0
 *rossa	r o s s a	0
-*rossa	r ɔ s s a	0
 *rēniō	r eː n i oː	0
 *rīdiō	r iː d i oː	0
 *rīdō	r iː d oː	0
@@ -623,7 +504,6 @@
 *rōsicō	r oː s i k oː	0
 *sagia	s a ɡ i a	0
 *sambatum	s a m b a t u m	0
-*sambatum	s a m β a t u m	0
 *sapeō	s a p e oː	0
 *sapēre	s a p eː r e	0
 *sarclāre	s a r k l aː r e	0
@@ -631,38 +511,29 @@
 *scermiō	s k e r m i oː	0
 *scermiō	s k ɛ r m i oː	0
 *scrībiō	s k r iː b i oː	0
-*scrībiō	s k r iː β i oː	0
 *sedentāre	s e d e n t aː r e	0
 *sedentō	s e d e n t oː	0
 *sedentō	s e d ɛ n t oː	0
 *sennus	s e n n u s	0
 *sennus	s ɛ n n u s	0
 *septembrius	s e p t e m b r i u s	0
-*septembrius	s e p t ɛ m β r i u s	0
 *sequiō	s e kʷ i oː	0
 *sequiō	s ɛ kʷ i oː	0
 *sequīre	s e kʷ iː r e	0
 *smeralda	s m e r a l d a	0
 *smeraldus	s m e r a l d u s	0
 *socra	s o k r a	0
-*socra	s ɔ k r a	0
 *solicli	s o l i k l iː	0
-*solicli	s ɔ l i k l iː	0
 *soliclus	s o l i k l u s	0
-*soliclus	s ɔ l i k l u s	0
 *sorbiō	s o r b i oː	0
-*sorbiō	s ɔ r β i oː	0
 *sorbīre	s o r b iː r e	0
-*sorbīre	s o r β iː r e	0
 *sortiārius	s o r t i aː r i u s	0
 *spiāre	s p i aː r e	0
 *spiō	s p i oː	0
 *strinctus	s t r i n k t u s	0
 *stunō	s t u n oː	0
 *subrīdere	s u b r iː d e r e	0
-*subrīdere	s u β r iː d e r e	0
 *subrīdō	s u b r iː d oː	0
-*subrīdō	s u β r iː d oː	0
 *sufferiō	s u f f e r i oː	0
 *sufferiō	s u f f ɛ r i oː	0
 *sufferīre	s u f f e r iː r e	0
@@ -673,20 +544,15 @@
 *sīcīlō	s iː k iː l oː	0
 *taranca	t a r a n k a	0
 *tardīvus	t a r d iː w u s	0
-*tardīvus	t a r d iː β u s	0
 *tastāre	t a s t aː r e	0
 *tastō	t a s t oː	0
 *teniō	t e n i oː	0
 *teniō	t ɛ n i oː	0
 *tenīre	t e n iː r e	0
 *toccō	t o k k oː	0
-*toccō	t ɔ k k oː	0
 *toppus	t o p p u s	0
-*toppus	t ɔ p p u s	0
 *torcere	t o r k e r e	0
-*torcere	t ɔ r k e r e	0
 *torcō	t o r k oː	0
-*torcō	t ɔ r k oː	0
 *tractiō	t r a k t i oː	0
 *tragināre	t r a ɡ i n aː r e	0
 *traginō	t r a ɡ i n oː	0
@@ -697,7 +563,6 @@
 *trochis	t r o kʰ i s	0
 *tropāre	t r o p aː r e	0
 *tropō	t r o p oː	0
-*tropō	t r ɔ p oː	0
 *trūdicō	t r uː d i k oː	0
 *tīmō	t iː m oː	0
 *tīrō	t iː r oː	0
@@ -708,37 +573,21 @@
 *undizāre	u n d i z z aː r e	0
 *undizō	u n d i z z oː	0
 *versūra	w e r s uː r a	0
-*versūra	β e r s uː r a	0
 *vestītūra	w e s t iː t uː r a	0
-*vestītūra	β e s t iː t uː r a	0
 *virdia	w i r d i a	0
-*virdia	β i r d i a	0
 *voleō	w o l e oː	0
-*voleō	β ɔ l e oː	0
 *voltāre	w o l t aː r e	0
-*voltāre	β o l t aː r e	0
 *voltō	w o l t oː	0
-*voltō	β ɔ l t oː	0
 *volēre	w o l eː r e	0
-*volēre	β o l eː r e	0
 *vēra	w eː r a	0
-*vēra	β eː r a	0
 *vērānum	w eː r aː n u m	0
-*vērānum	β eː r aː n u m	0
 *vēxīca	w eː k s iː k a	0
-*vēxīca	β eː s iː k a	0
 *vīsāticum	w iː s aː t i k u m	0
-*vīsāticum	β iː s aː t i k u m	0
 *wadaniō	w a d a n i oː	0
-*wadaniō	β a d a n i oː	0
 *wardō	w a r d oː	0
-*wardō	β a r d oː	0
 *warniō	w a r n i oː	0
-*warniō	β a r n i oː	0
 *werra	w e r r a	0
-*werra	β ɛ r r a	0
 *werrizō	w e r r i z z oː	0
-*werrizō	β e r r i z z oː	0
 *ācrus	aː k r u s	0
 *ārdere	aː r d e r e	0
 *ārdō	aː r d oː	0
@@ -793,7 +642,6 @@ abambulō	a b a m b u l oː	0
 abamita	a b a m i t a	0
 abannātiō	a b a n n aː t i oː	0
 abante	a b a n t e	0
-abante	a β a n t e	0
 abantius	a b a n t i u s	0
 abantēa	a b a n t eː a	0
 abantēa	a b a n t eː aː	0
@@ -2129,7 +1977,6 @@ affīdō	a f f i d o	0
 affīdō	a f f iː d oː	0
 affīgō	a f f iː ɡ oː	0
 affīnis	a f f iː n i s	0
-afghanus	a f ɡʰ a n u s	0
 afrānius	a f r aː n i u s	0
 aga	a ɡ a	0
 agaga	a ɡ a ɡ a	0
@@ -3252,7 +3099,6 @@ apothēcārius	a p o tʰ eː k aː r i u s	0
 apothēcō	a p o tʰ eː k oː	0
 apozema	a p o d d͡z e m a	0
 apozema	a p o z z e m a	0
-apozema	a p ɔ z z e m a	0
 apozȳmō	a p o z z yː m oː	0
 appalachiānus	a p p a l a kʰ i aː n u s	0
 apparāta	a p p a r aː t a	0
@@ -4265,7 +4111,6 @@ avestānus	a w e s t aː n u s	0
 avicantus	a w i k a n t u s	0
 avicella	a v i t͡ʃ e l l a	0
 avicella	a w i k e l l a	0
-avicella	a β i k ɛ l l a	0
 avicula	a w i k u l a	0
 aviculārius	a w i k u l aː r i u s	0
 aviditer	a w i d i t e r	0
@@ -4338,7 +4183,6 @@ babullius	b a b u l l i u s	0
 baburrus	b a b u r r u s	0
 babylōnia	b a b i l o n i a	0
 babylōnia	b a b y l oː n i a	0
-babylōnia	β a β e l oː n i a	0
 babylōnicus	b a b y l oː n i k u s	0
 bacca	b aː k k a	2
 baccanae	b a k k a n a e̯	2
@@ -4474,7 +4318,6 @@ barbāna	b a r b aː n a	0
 barbānis	b a r b aː n i s	0
 barbānus	b a r b aː n u s	0
 barbānīs	b a r b aː n iː s	0
-barbās	b a ɾ β ɐ ʃ	0
 barbātius	b a r b aː t i u s	0
 barbātus	b a r b aː t u s	0
 barbēsula	b a r b eː s u l a	0
@@ -4721,7 +4564,6 @@ bibulus	b i b u l u s	4
 bibāx	b i b aː k s	0
 bibō	b i b o	0
 bibō	b i b oː	0
-bibō	β i β oː	0
 bibōnius	b i b oː n i u s	0
 bibōsus	b i b oː s u s	0
 bicarīnātus	b i k a r iː n aː t u s	0
@@ -4819,7 +4661,6 @@ bisētus	b i s eː t u s	0
 bisīgnātus	b i s iː ɡ n aː t u s	0
 bisōmum	b i s o m u m	0
 bisōmum	b i s oː m u m	0
-bisōmum	β i s oː m u m	0
 bisōn	b i s oː n	0
 bitius	b i t i u s	0
 bituitus	b i t u i t u s	0
@@ -6672,7 +6513,6 @@ christogramma	k r i s t o ɡ r a m m a	0
 christogramma	kʰ r i s t o ɡ r a m m a	0
 chronicus	k r o n i k u s	0
 chronicus	kʰ r o n i k u s	0
-chronicus	kʰ r ɔ n i k u s	0
 chrysogaster	kʰ r y s o ɡ a s t e r	0
 chrysopterus	kʰ r y s o p t e r u s	0
 chrystallinus	kʰ r y s t a l l i n u s	0
@@ -7410,7 +7250,6 @@ columbus	k o l u m b u s	17
 columbārium	k o l u m b aː r i u m	0
 columbīnus	k o l u m b i n u s	0
 columbīnus	k o l u m b iː n u s	0
-columbīnus	k o l u m β iː n u s	0
 columella	k o l u m e l l a	8
 columen	k o l u m e n	3
 columna	k o l u m n a	35
@@ -9549,7 +9388,6 @@ deificātiō	d e i f i k aː t i oː	0
 deificō	d e i f i k o	0
 deificō	d e i f i k oː	0
 deiformis	d e i f o r m i s	0
-deiformis	d e i f ɔ r m i s	0
 dein	d e i n	90
 dein	d e i̯ n	90
 deinceps	d e i n k e p s	12
@@ -9585,7 +9423,6 @@ dentārius	d e n t aː r i u s	0
 dentātus	d e n t aː t u s	0
 deonerō	d e o n e r oː	0
 deorsum	d e o r s u m	13
-deorsum	d e ɔ r s u m	13
 depstīcius	d e p s t iː k i u s	0
 depsō	d e p s oː	0
 der	d e r	179
@@ -9748,7 +9585,6 @@ digitus	d i ɡ i t u s	14
 digitābulum	d i ɡ i t aː b u l u m	0
 digitālis	d i ɡ i t aː l i s	0
 digitātus	d i ɡ i t aː t u s	0
-digitō	d i x i t o	0
 digitōrum	d i ɡ i t oː r u m	0
 dignitās	d i ɡ n i t aː s	0
 dignus	d i ɡ n u s	9
@@ -10063,7 +9899,6 @@ domitius	d o m i t i u s	18
 domitor	d o m i t o r	0
 domitūra	d o m i t uː r a	0
 domna	d o m n a	3
-domna	d ɔ m n a	3
 domuitiō	d o m u i t i oː	0
 domus	d o m u s	466
 domā	d o m aː	0
@@ -10550,7 +10385,6 @@ dēlātor	d e l a t o r	0
 dēlātor	d eː l aː t o r	0
 dēlēbilis	d e l e b i l i s	0
 dēlēbilis	d eː l eː b i l i s	0
-dēlēbilis	d eː l eː β i l i s	0
 dēlēgō	d eː l eː ɡ oː	0
 dēlēniō	d eː l eː n i oː	0
 dēlētiō	d e l e t͡s i o	0
@@ -10826,7 +10660,6 @@ dēvirginō	d eː w i r ɡ i n oː	0
 dēvius	d eː w i u s	0
 dēviātiō	d e v i a t͡s i o	0
 dēviātiō	d eː w i aː t i oː	0
-dēviātiō	d eː β i aː t i oː	0
 dēvocō	d eː w o k oː	0
 dēvolve	d eː w o l w e	0
 dēvolvēns	d eː w o l w e n s	0
@@ -11379,10 +11212,8 @@ epochās	e p o k a s	0
 epochās	e p o kʰ aː s	0
 epops	e p o p s	0
 epopta	e p o p t a	0
-epopta	e p ɔ p t a	0
 epoptēs	e p o p t e s	0
 epoptēs	e p o p t eː s	0
-epoptēs	e p ɔ p t eː s	0
 eporedia	e p o r e d i a	2
 eporedorīx	e p o r e d o r iː k s	0
 epos	e p o s	3
@@ -11659,7 +11490,6 @@ exagium	e k s a ɡ i u m	0
 exalbēscō	e k s a l b eː s k oː	0
 exalbō	e k s a l b o	0
 exalbō	e k s a l b oː	0
-exalbō	e s a l β oː	0
 exaltō	e k s a l t oː	0
 exampaeus	e k s a m p a e̯ u s	0
 examplexor	e k s a m p l e k s o r	0
@@ -13208,7 +13038,6 @@ fūnārius	f uː n aː r i u s	0
 fūnētum	f uː n eː t u m	0
 fūr	f u r	0
 fūr	f uː r	0
-fūrem	f u r ẽ j̃	0
 fūrius	f uː r i u s	0
 fūror	f uː r o r	0
 fūrtificus	f uː r t i f i k u s	0
@@ -13578,7 +13407,6 @@ geōrgiānī	ɡ e oː r ɡ i aː n iː	0
 geōrgiānō	ɡ e oː r ɡ i aː n oː	0
 geōrgiānōs	ɡ e oː r ɡ i aː n oː s	0
 geōrgiēnsis	ɡ e oː r ɡ i e n s i s	0
-ghanēnsis	ɡʰ a n e n s i s	0
 gibber	ɡ i b b e r	1
 gibbiflōrus	ɡ i b b i f l oː r u s	0
 gibbirōstris	ɡ i b b i r oː s t r i s	0
@@ -13769,7 +13597,6 @@ graecīnus	ɡ r a e̯ k iː n u s	0
 grallae	ɡ r a l l a e̯	0
 graminicolus	ɡ r a m i n i k o l u s	0
 gramma	ɡ r a m m a	8
-grammatica	ɡ ɾ a m m a t i k a	73
 grammaticus	ɡ r a m m a t i k u s	16
 grammaticālis	ɡ r a m m a t i k aː l i s	0
 grammium	ɡ r a m m i u m	0
@@ -15190,7 +15017,6 @@ impendeō	i m p e n d e oː	0
 impendō	i m p e n d oː	0
 impenetrābilis	i m p e n e t r a b i l i s	0
 impenetrābilis	i m p e n e t r aː b i l i s	0
-impenetrābilis	i m p e n e t r aː β i l i s	0
 impennis	i m p e n n i s	0
 imperceptibilis	i m p e r k e p t i b i l i s	0
 imperfectus	i m p e r f e k t u s	4
@@ -15366,7 +15192,6 @@ inalbeō	i n a l b e oː	0
 inalbēscō	i n a l b eː s k oː	0
 inalbō	i n a l b o	0
 inalbō	i n a l b oː	0
-inalbō	i n a l β oː	0
 inaltō	i n a l t oː	0
 inambulō	i n a m b u l oː	0
 inanimus	i n a n i m u s	0
@@ -16003,7 +15828,6 @@ innovat	i n n o w a t	0
 innovō	i n n o w oː	0
 innoxius	i n n o k s i u s	1
 innubus	i n n u b u s	0
-innubus	i n n u β u s	0
 innumerus	i n n u m e r u s	0
 innumerābilis	i n n u m e r aː b i l i s	0
 innuō	i n n u oː	0
@@ -16249,7 +16073,6 @@ interminis	i n t e r m i n i s	0
 interminor	i n t e r m i n o r	0
 interminābilis	i n t e r m i n a b i l i s	0
 interminābilis	i n t e r m i n aː b i l i s	0
-interminābilis	i n t e r m i n aː β i l i s	0
 intermisceō	i n t e r m i s k e oː	0
 intermittō	i n t e r m i t t oː	0
 intermorior	i n t e r m o r i o r	0
@@ -17335,7 +17158,6 @@ latīnitās	l a t iː n i t aː s	0
 latīnus	l a t iː n u s	0
 latīnē	l a t iː n eː	0
 laubia	l a u̯ b i a	1
-laubia	l a u̯ β i a	1
 laudanda	l a u̯ d a n d a	1
 laudanda	l a u̯ d a n d aː	1
 laudant	l a u̯ d a n t	6
@@ -22066,7 +21888,6 @@ optemperō	o p t e m p e r oː	0
 opticus	o p t i k u s	1
 optime	o p t i m e	68
 optimus	o p t i m u s	42
-optimus	ɔ p t i m u s	42
 optimās	o p t i m aː s	0
 optimē	o p t i m eː	0
 optingō	o p t i n ɡ oː	0
@@ -28221,7 +28042,6 @@ sincērus	s i n k eː r u s	0
 sindunī	s i n d u n iː	0
 sindus	s i n d u s	0
 sindī	s i n d iː	0
-sine	s i n ɐ	610
 sine	s i n ɛ	610
 singae	s i n ɡ a e̯	0
 singamēs	s i n ɡ a m eː s	0
@@ -28812,7 +28632,6 @@ strāmineus	s t r aː m i n e u s	0
 strāta	s t r aː t a	0
 strātum	s t r aː t u m	0
 strātus	s t r aː t u s	0
-strātō	s t r a t ɔ	0
 strēnue	s t r eː n u e	0
 strēnuitās	s t r eː n u i t aː s	0
 strēnuus	s t r eː n u u s	0
@@ -31643,7 +31462,6 @@ undique	u n d i kʷ e	18
 undisonus	u n d i s o n u s	0
 unditānum	u n d i t aː n u m	0
 undivagus	u n d i w a ɡ u s	0
-undivagus	u n d i β a ɡ u s	0
 undula	u n d u l a	0
 undulātus	u n d u l aː t u s	0
 undulō	u n d u l oː	0
@@ -31754,7 +31572,6 @@ uīuus	w iː w u s	0
 vacat	w a k a t	2
 vacca	v a k k a	3
 vacca	w a k k a	3
-vacca	β a k k a	3
 vaccifōrmis	w a k k i f oː r m i s	0
 vaccula	w a k k u l a	0
 vaccīnium	w a k k iː n i u m	0
@@ -31908,7 +31725,6 @@ vatīnius	w a t iː n i u s	0
 vavatō	w a w a t oː	0
 veamīnī	w e a m iː n iː	0
 veclus	w e k l u s	0
-veclus	β ɛ k l u s	0
 vecta	w e k t a	1
 vectae	w e k t a e̯	6
 vectam	w e k t a m	1
@@ -32233,7 +32049,6 @@ vicēnsimus	w i k e n s i m u s	0
 videntēs	w i d e n t eː s	0
 videō	v i d e o	0
 videō	w i d e oː	0
-videō	β i d e oː	0
 vidua	w i d u a	29
 viducassēs	w i d u k a s s eː s	0
 viduus	w i d u u s	2
@@ -32392,7 +32207,6 @@ viscōsus	w i s k oː s u s	0
 visellius	w i s e l l i u s	1
 vispelliō	v i s p e l l i o	0
 vispelliō	w i s p e l l i oː	0
-vispelliō	β i s p ɛ l l i oː	0
 vispillō	w i s p i l l oː	0
 visucius	w i s u k i u s	0
 visurgis	w i s u r ɡ i s	5
@@ -32582,7 +32396,6 @@ vulgō	w u l ɡ oː	0
 vulnerābilis	w u l n e r aː b i l i s	0
 vulnerō	v u l n e r o	0
 vulnerō	w u l n e r oː	0
-vulnerō	β u l n e r oː	0
 vulnificus	w u l n i f i k u s	0
 vulnus	w u l n u s	14
 vulpis	w u l p i s	8
@@ -32652,10 +32465,8 @@ vēdiovis	v e d i o v i s	0
 vēdiovis	w eː d i o w i s	0
 vēdius	v e d i u s	0
 vēdius	w eː d i u s	0
-vēdius	β eː d i u s	0
 vēdīus	v e d i u s	0
 vēdīus	w eː d iː u s	0
-vēdīus	β eː d iː u s	0
 vēgrandis	w eː ɡ r a n d i s	0
 vēiovis	v e j o v i s	0
 vēiovis	w eː j o w i s	0
@@ -32922,7 +32733,6 @@ wastina	w a s t i n a	0
 werpiō	w e r p i oː	0
 werra	v e r r a	0
 werra	w e r r a	0
-werra	β ɛ r r a	0
 westmonastēriēnsis	v e s t m o n a s t e r i e n s i s	0
 westmonastēriēnsis	w e s t m o n a s t eː r i e n s i s	0
 widmānstadius	v i d m a n s t a d i u s	0
@@ -33291,7 +33101,6 @@ zȳthum	z yː tʰ u m	0
 ēbria	eː b r i aː	0
 ēbrietās	e b r i e t a s	0
 ēbrietās	eː b r i e t aː s	0
-ēbrietās	eː β r i e t aː s	0
 ēbriolus	eː b r i o l u s	0
 ēbriolātus	eː b r i o l aː t u s	0
 ēbrium	eː b r i u m	0
@@ -33521,7 +33330,6 @@ zȳthum	z yː tʰ u m	0
 ērogō	eː r o ɡ oː	0
 ērubēscō	eː r u b eː s k oː	0
 ērudiō	eː r u d i oː	0
-ērudīta	e ɾ u d i t a	0
 ērudīte	eː r u d iː t e	0
 ērudītiō	eː r u d iː t i oː	0
 ērudītulus	eː r u d iː t u l u s	0


### PR DESCRIPTION
* Logs bad phonemes (closes #156)
* Makes whitelist functions semiprivate
* Factors `postprocess` script into `split` and `whitelist` portions; makes it easier to run one but not the other
* Makes whitelisting sensitive to the presence of whitelists: if one exist, it is applied
* Runs this process over Latin and regenerates the summaries

FYI: @AaronGoyzueta @jacksonllee 