### PR TITLE
[quc] Allow space in K'iche' words.

### DIFF
--- a/data/wikipron/src/languages.json
+++ b/data/wikipron/src/languages.json
@@ -440,7 +440,9 @@
         "iso639_name": "K'iche'",
         "wiktionary_name": "K'iche'",
         "wiktionary_code": "quc",
-        "casefold": true
+        "casefold": true,
+        "no_skip_spaces_word": true,
+        "no_skip_spaces_pron": true
     },
     "kbd": {
         "iso639_name": "Kabardian",


### PR DESCRIPTION
This still falls just short of 100 (96) though there are 117 pronunciations according to Wiktionary.

Closes #159 (though not satisfactorily).

- [ ] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
