### PR TITLE
Add --no-tone flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Unreleased
     New TSV is placed under tsv/\*\_filtered.tsv. (\#154).
 -   Added Manchu (`mnc`). (\#185)
 -   Added Polabian (`pox`). (\#186)
+-   Added `--no-tone` flag. (\#188)
 
 -   Updated generate_summary to reflect presence of 'filtered' tsv. (\#154)
 ### Deprecated

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -71,7 +71,7 @@ def test_no_segment(no_segment, input_pron, expected_pron):
     "no_tone, input_pron, expected_pron",
     [
         (False, "aˈɓa.ɽé", "a ˈɓ a . ɽ é"),
-        (True, "aˈɓa.ɽé", "a ˈɓ a . ɽ e"),
+        (True, "aˈɓa.ɽé", "a ˈɓ a . ɽ e"),
         (
             True,
             "feɪ̯³⁵ʈ͡ʂaɪ̯³⁵kʰwaɪ̯⁵¹⁻⁵³lɤ⁵¹ʂweɪ̯²¹⁴⁻²¹⁽⁴⁾",
@@ -86,6 +86,7 @@ def test_no_segment(no_segment, input_pron, expected_pron):
 )
 def test_no_tone(no_tone, input_pron, expected_pron):
     config = config_factory(no_tone=no_tone)
+    print("ANSWER", config.process_pron(input_pron))
     assert config.process_pron(input_pron) == expected_pron
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -82,11 +82,11 @@ def test_no_segment(no_segment, input_pron, expected_pron):
             "kra˨˩.duːk̚˨˩.ton˥˩.kʰaː˩˩˦",
             "k r a . d uː k̚ . t o n . kʰ aː",
         ),
+        (True, "aˈt͡ʃe.w⁽ᵝ⁾á", "a ˈt͡ʃ e . w ⁽ᵝ ⁾ a"),
     ],
 )
 def test_no_tone(no_tone, input_pron, expected_pron):
     config = config_factory(no_tone=no_tone)
-    print("ANSWER", config.process_pron(input_pron))
     assert config.process_pron(input_pron) == expected_pron
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -72,12 +72,21 @@ def test_no_segment(no_segment, input_pron, expected_pron):
     [
         (False, "aˈɓa.ɽé", "a ˈɓ a . ɽ é"),
         (True, "aˈɓa.ɽé", "a ˈɓ a . ɽ e"),
-        (True, "feɪ̯³⁵ʈ͡ʂaɪ̯³⁵kʰwaɪ̯⁵¹⁻⁵³lɤ⁵¹ʂweɪ̯²¹⁴⁻²¹⁽⁴⁾", "f e ɪ̯ ʈ͡ʂ a ɪ̯ kʰ w a ɪ̯ l ɤ ʂ w e ɪ̯"),
-        (True, "kra˨˩.duːk̚˨˩.ton˥˩.kʰaː˩˩˦", "k r a . d uː k̚ . t o n . kʰ aː")
+        (
+            True,
+            "feɪ̯³⁵ʈ͡ʂaɪ̯³⁵kʰwaɪ̯⁵¹⁻⁵³lɤ⁵¹ʂweɪ̯²¹⁴⁻²¹⁽⁴⁾",
+            "f e ɪ̯ ʈ͡ʂ a ɪ̯ kʰ w a ɪ̯ l ɤ ʂ w e ɪ̯",
+        ),
+        (
+            True,
+            "kra˨˩.duːk̚˨˩.ton˥˩.kʰaː˩˩˦",
+            "k r a . d uː k̚ . t o n . kʰ aː",
+        ),
     ],
 )
 def test_no_tone(no_tone, input_pron, expected_pron):
     config = config_factory(no_tone=no_tone)
+    print("ANSWER", config.process_pron(input_pron))
     assert config.process_pron(input_pron) == expected_pron
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -68,6 +68,20 @@ def test_no_segment(no_segment, input_pron, expected_pron):
 
 
 @pytest.mark.parametrize(
+    "no_tone, input_pron, expected_pron",
+    [
+        (False, "aˈɓa.ɽé", "a ˈɓ a . ɽ é"),
+        (True, "aˈɓa.ɽé", "a ˈɓ a . ɽ e"),
+        (True, "feɪ̯³⁵ʈ͡ʂaɪ̯³⁵kʰwaɪ̯⁵¹⁻⁵³lɤ⁵¹ʂweɪ̯²¹⁴⁻²¹⁽⁴⁾", "f e ɪ̯ ʈ͡ʂ a ɪ̯ kʰ w a ɪ̯ l ɤ ʂ w e ɪ̯"),
+        (True, "kra˨˩.duːk̚˨˩.ton˥˩.kʰaː˩˩˦", "k r a . d uː k̚ . t o n . kʰ aː")
+    ],
+)
+def test_no_tone(no_tone, input_pron, expected_pron):
+    config = config_factory(no_tone=no_tone)
+    assert config.process_pron(input_pron) == expected_pron
+
+
+@pytest.mark.parametrize(
     "error, cut_off_date, word_available_date, expected",
     [
         # Input cut_off_date is invalid.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -86,7 +86,6 @@ def test_no_segment(no_segment, input_pron, expected_pron):
 )
 def test_no_tone(no_tone, input_pron, expected_pron):
     config = config_factory(no_tone=no_tone)
-    print("ANSWER", config.process_pron(input_pron))
     assert config.process_pron(input_pron) == expected_pron
 
 

--- a/wikipron/cli.py
+++ b/wikipron/cli.py
@@ -84,6 +84,11 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
         action="store_true",
         help="Skip spaces in the transcription",
     )
+    parser.add_argument(
+        "--no-tone",
+        action="store_true",
+        help="Remove tones in the transcription.",
+    )
     return parser.parse_args(args)
 
 

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -35,7 +35,8 @@ _DIALECT_XPATH_SELECTOR_TEMPLATE = (
 _PHONEMES_REGEX = r"/(.+?)/"
 _PHONES_REGEX = r"\[(.+?)\]"
 
-_TONES_REGEX = r"[˥˦˧˨˩⁰¹²³⁴⁵⁶⁷⁸⁹⁻⁽⁾◌̋ ◌̌ ◌̏ ◌̀ ◌́ ◌̂ ◌̄ ◌᷄◌᷅◌᷆◌᷇◌᷈◌᷉↑↓↗↘]"
+_TONES_REGEX = r"[˥˦˧˨˩⁰¹²³⁴⁵⁶⁷⁸⁹⁻◌̋ ◌̌ ◌̏ ◌̀ ◌́ ◌̂ ◌̄ ◌᷄◌᷅◌᷆◌᷇◌᷈◌᷉↑↓↗↘]"
+_PARENS_REGEX = rf"⁽{_TONES_REGEX}+⁾"
 
 
 class Config:
@@ -135,6 +136,7 @@ class Config:
         if no_syllable_boundaries:
             processors.append(functools.partial(re.sub, r"\.", ""))
         if no_tone:
+            processors.append(functools.partial(re.sub, _PARENS_REGEX, ""))
             processors.append(functools.partial(re.sub, _TONES_REGEX, ""))
         if not no_segment:
             processors.append(

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -2,7 +2,6 @@ import datetime
 import functools
 import logging
 import re
-import unicodedata
 
 from typing import Callable, Optional
 
@@ -36,7 +35,7 @@ _DIALECT_XPATH_SELECTOR_TEMPLATE = (
 _PHONEMES_REGEX = r"/(.+?)/"
 _PHONES_REGEX = r"\[(.+?)\]"
 
-_TONES_REGEX = r"[˥˦˧˨˩⁰¹²³⁴⁵⁶⁷⁸⁹⁻⁽⁾◌̋ ◌̌ ◌̏ ◌̀ ◌́ ◌̂ ◌̄ ◌᷄◌᷅◌᷆◌᷇◌᷈◌᷉]"
+_TONES_REGEX = r"[˥˦˧˨˩⁰¹²³⁴⁵⁶⁷⁸⁹⁻⁽⁾◌̋ ◌̌ ◌̏ ◌̀ ◌́ ◌̂ ◌̄ ◌᷄◌᷅◌᷆◌᷇◌᷈◌᷉↑↓↗↘]"
 
 
 class Config:
@@ -136,7 +135,6 @@ class Config:
         if no_syllable_boundaries:
             processors.append(functools.partial(re.sub, r"\.", ""))
         if no_tone:
-            processors.append(functools.partial(unicodedata.normalize, "NFD"))
             processors.append(functools.partial(re.sub, _TONES_REGEX, ""))
         if not no_segment:
             processors.append(

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -37,8 +37,7 @@ _PHONEMES_REGEX = r"/(.+?)/"
 _PHONES_REGEX = r"\[(.+?)\]"
 
 _TONES_REGEX = (
-    r"[\u02E5-\u02E9\u00b2-\u00b3\u00b9\u2074-\u2079"
-    r"\u030B\u030C\u030F\u0300-\u0302\u0304\u1DC4-\u1DC9\u207B-\u207E]"
+    r"[˥˦˧˨˩⁰¹²³⁴⁵⁶⁷⁸⁹⁻⁽⁾\u030B\u030C\u030F\u0300-\u0302\u0304\u1DC4-\u1DC9]"
 )
 
 

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -38,6 +38,7 @@ _PHONES_REGEX = r"\[(.+?)\]"
 
 _TONES_REGEX = r"[˥˦˧˨˩⁰¹²³⁴⁵⁶⁷⁸⁹⁻⁽⁾◌̋ ◌̌ ◌̏ ◌̀ ◌́ ◌̂ ◌̄ ◌᷄◌᷅◌᷆◌᷇◌᷈◌᷉]"
 
+
 class Config:
     """Configuration for a scraping run.
 

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -36,10 +36,7 @@ _DIALECT_XPATH_SELECTOR_TEMPLATE = (
 _PHONEMES_REGEX = r"/(.+?)/"
 _PHONES_REGEX = r"\[(.+?)\]"
 
-_TONES_REGEX = (
-    r"[˥˦˧˨˩⁰¹²³⁴⁵⁶⁷⁸⁹⁻⁽⁾\u030B\u030C\u030F\u0300-\u0302\u0304\u1DC4-\u1DC9]"
-)
-
+_TONES_REGEX = r"[˥˦˧˨˩⁰¹²³⁴⁵⁶⁷⁸⁹⁻⁽⁾◌̋ ◌̌ ◌̏ ◌̀ ◌́ ◌̂ ◌̄ ◌᷄◌᷅◌᷆◌᷇◌᷈◌᷉]"
 
 class Config:
     """Configuration for a scraping run.

--- a/wikipron/extract/core.py
+++ b/wikipron/extract/core.py
@@ -3,7 +3,7 @@
 import logging
 import re
 import typing
-
+import unicodedata
 import requests_html
 
 
@@ -35,7 +35,7 @@ def yield_pron(
         if _skip_pron(pron, config):
             continue
         try:
-            pron = config.process_pron(pron)
+            pron = config.process_pron(unicodedata.normalize("NFD", pron))
         except IndexError:
             logging.info(
                 "IndexError encountered processing %s during scrape of %s",

--- a/wikipron/extract/core.py
+++ b/wikipron/extract/core.py
@@ -36,7 +36,9 @@ def yield_pron(
         if _skip_pron(pron, config):
             continue
         try:
-            pron = config.process_pron(unicodedata.normalize("NFD", pron))
+            # All pronunciation processing is done in NFD-space.
+            pron = unicodedata.normalize("NFD", pron)
+            pron = config.process_pron(pron)
         except IndexError:
             logging.info(
                 "IndexError encountered processing %s during scrape of %s",

--- a/wikipron/extract/core.py
+++ b/wikipron/extract/core.py
@@ -4,6 +4,7 @@ import logging
 import re
 import typing
 import unicodedata
+
 import requests_html
 
 

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -42,9 +42,9 @@ def _scrape_once(data, config: Config) -> Iterator[WordPronPair]:
         ):
             continue
         request = session.get(_PAGE_TEMPLATE.format(word=word), timeout=10)
-        word = unicodedata.normalize("NFD", word)
         for word, pron in config.extract_word_pron(word, request, config):
-            yield word, unicodedata.normalize('NFC', pron)
+            # Pronunciation processing is done in NFD-space; we convert back to NFC aftewards
+            yield word, unicodedata.normalize("NFC", pron)
 
 
 def scrape(config: Config) -> Iterator[WordPronPair]:

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -2,6 +2,7 @@ import re
 
 import requests
 import requests_html
+import unicodedata
 
 from wikipron.config import Config
 from wikipron.typing import Iterator, WordPronPair
@@ -41,8 +42,9 @@ def _scrape_once(data, config: Config) -> Iterator[WordPronPair]:
         ):
             continue
         request = session.get(_PAGE_TEMPLATE.format(word=word), timeout=10)
+        word = unicodedata.normalize("NFD", word)
         for word, pron in config.extract_word_pron(word, request, config):
-            yield word, pron
+            yield word, unicodedata.normalize('NFC', pron)
 
 
 def scrape(config: Config) -> Iterator[WordPronPair]:

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -43,7 +43,8 @@ def _scrape_once(data, config: Config) -> Iterator[WordPronPair]:
             continue
         request = session.get(_PAGE_TEMPLATE.format(word=word), timeout=10)
         for word, pron in config.extract_word_pron(word, request, config):
-            # Pronunciation processing is done in NFD-space; we convert back to NFC aftewards
+            # Pronunciation processing is done in NFD-space;
+            # we convert back to NFC aftewards.
             yield word, unicodedata.normalize("NFC", pron)
 
 

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -1,8 +1,8 @@
 import re
+import unicodedata
 
 import requests
 import requests_html
-import unicodedata
 
 from wikipron.config import Config
 from wikipron.typing import Iterator, WordPronPair


### PR DESCRIPTION
- [X] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.

This PR offers a potential solution to issue #91. It seems to work as desired and removes all the tones mentioned by Jackson in #91.The range of tones removed is demonstrated in the changes to `test_config.py`. 
The [regex used to target the various tones](https://github.com/lfashby/wikipron/blob/9001fe5317f2c4b0d819dab53184894e2c225f62/wikipron/config.py#L39) we want to remove is not particularly 'legible'. Perhaps I should add comments detailing the character each codepoint refers to? Or I could replace the codepoints with characters? If anyone has any other suggestions let me know. 
