### PR TITLE
[ban] Splitting Balinese into Latin and Balinese scripts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Unreleased
 -   Added `tyv` to `languagecodes.py` (\#203, \#205)
 -   Added `bcl`, `egl`, `izh`, `ltg`, `azg`, `kir` and `mga` to `languagecodes.py`. (\#205)
 -   Added `nep` to `languagecodes.py`. (\#206)
+-   Split `ban` into Latin and Balinese scripts. (\#214)
 
 ### Changed
 

--- a/data/README.md
+++ b/data/README.md
@@ -22,7 +22,7 @@
 | [TSV](tsv/aze_latn_phonemic.tsv) | aze | Azerbaijani | Azerbaijani (Latin) | True | Phonemic | 225 |
 | [TSV](tsv/aze_latn_phonetic.tsv) | aze | Azerbaijani | Azerbaijani (Latin) | True | Phonetic | 2,579 |
 | [TSV](tsv/bdq_phonemic.tsv) | bdq | Bahnar | Bahnar | True | Phonemic | 149 |
-| [TSV](tsv/ban_phonemic.tsv) | ban | Balinese | Balinese | False | Phonemic | 181 |
+| [TSV](tsv/ban_bali_phonemic.tsv) | ban | Balinese | Balinese (Balinese) | True | Phonemic | 178 |
 | [TSV](tsv/bak_phonemic.tsv) | bak | Bashkir | Bashkir | True | Phonemic | 108 |
 | [TSV](tsv/bak_phonetic.tsv) | bak | Bashkir | Bashkir | True | Phonetic | 2,006 |
 | [TSV](tsv/baq_phonemic.tsv) | baq | Basque | Basque | True | Phonemic | 1,256 |
@@ -73,7 +73,6 @@
 | [TSV](tsv/fin_phonemic.tsv) | fin | Finnish | Finnish | True | Phonemic | 56,063 |
 | [TSV](tsv/fin_phonetic.tsv) | fin | Finnish | Finnish | True | Phonetic | 56,055 |
 | [TSV](tsv/fre_phonemic.tsv) | fre | French | French | True | Phonemic | 56,296 |
-| [TSV](tsv/fre_phonemic_filtered.tsv) | fre | French | French | True | Phonemic_filtered | 56,186 |
 | [TSV](tsv/fre_phonetic.tsv) | fre | French | French | True | Phonetic | 185 |
 | [TSV](tsv/glg_phonemic.tsv) | glg | Galician | Galician | True | Phonemic | 4,904 |
 | [TSV](tsv/glg_phonetic.tsv) | glg | Galician | Galician | True | Phonetic | 867 |

--- a/data/languages_summary.tsv
+++ b/data/languages_summary.tsv
@@ -20,7 +20,7 @@ ast_phonetic.tsv	ast	Asturian	Asturian	True	Phonetic	131
 aze_latn_phonemic.tsv	aze	Azerbaijani	Azerbaijani (Latin)	True	Phonemic	225
 aze_latn_phonetic.tsv	aze	Azerbaijani	Azerbaijani (Latin)	True	Phonetic	2579
 bdq_phonemic.tsv	bdq	Bahnar	Bahnar	True	Phonemic	149
-ban_phonemic.tsv	ban	Balinese	Balinese	False	Phonemic	181
+ban_bali_phonemic.tsv	ban	Balinese	Balinese (Balinese)	True	Phonemic	178
 bak_phonemic.tsv	bak	Bashkir	Bashkir	True	Phonemic	108
 bak_phonetic.tsv	bak	Bashkir	Bashkir	True	Phonetic	2006
 baq_phonemic.tsv	baq	Basque	Basque	True	Phonemic	1256
@@ -71,7 +71,6 @@ fao_phonetic.tsv	fao	Faroese	Faroese	True	Phonetic	1123
 fin_phonemic.tsv	fin	Finnish	Finnish	True	Phonemic	56063
 fin_phonetic.tsv	fin	Finnish	Finnish	True	Phonetic	56055
 fre_phonemic.tsv	fre	French	French	True	Phonemic	56296
-fre_phonemic_filtered.tsv	fre	French	French	True	Phonemic_filtered	56186
 fre_phonetic.tsv	fre	French	French	True	Phonetic	185
 glg_phonemic.tsv	glg	Galician	Galician	True	Phonemic	4904
 glg_phonetic.tsv	glg	Galician	Galician	True	Phonetic	867

--- a/data/src/languages.json
+++ b/data/src/languages.json
@@ -119,7 +119,11 @@
         "iso639_name": "Balinese",
         "wiktionary_name": "Balinese",
         "wiktionary_code": "ban",
-        "casefold": false
+        "casefold": true,
+        "script": {
+            "bali": "Balinese",
+            "latn": "Latin"
+        }
     },
     "bak": {
         "iso639_name": "Bashkir",

--- a/data/tsv/ban_bali_phonemic.tsv
+++ b/data/tsv/ban_bali_phonemic.tsv
@@ -1,6 +1,3 @@
-apa	a p ə
-dalem	d a l ə m
-puputan	p u p u t a n
 ᬅᬃᬘᬵ	a r t͡ʃ ə
 ᬅᬃᬣ	a r t ə
 ᬅᬗ᭄ᬕᬭ	a ŋ ɡ a r ə


### PR DESCRIPTION
Please note: This refresh removes `tsv/fre_phonemic_filtered.tsv`that is currently missing from the HEAD. It was probably accidentally omitted from the last submitted PR.

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
