### PR TITLE
[kir] Split Kyrgyz into Cyrillic and Arabic scripts.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,7 @@ Unreleased
 -   Added `tyv` to `languagecodes.py` (\#203, \#205)
 -   Added `bcl`, `egl`, `izh`, `ltg`, `azg`, `kir` and `mga` to `languagecodes.py`. (\#205)
 -   Added `nep` to `languagecodes.py`. (\#206)
+-   Split `kir` into Cyrillic and Arabic. (\#216)
 
 ### Changed
 

--- a/data/src/languages.json
+++ b/data/src/languages.json
@@ -539,7 +539,11 @@
         "iso639_name": "Kirghiz",
         "wiktionary_name": "Kyrgyz",
         "wiktionary_code": "ky",
-        "casefold": true
+        "casefold": true,
+        "script": {
+            "ara": "Arabic",
+            "cyrl": "Cyrillic"
+        }
     },
     "lmy": {
         "iso639_name": "Lamboya",


### PR DESCRIPTION
- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
