### PR TITLE
FIX specify UTF-8 in handling text files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,6 +57,7 @@ Unreleased
 
 ### Changed
 
+-   Specified UTF-8 encoding in handling text files. (\#221)
 -   Renamed `.whitelist` file extension name as `.phones`. (\#207)
 
 ### Deprecated

--- a/data/frequencies/grab_wortschatz_data.py
+++ b/data/frequencies/grab_wortschatz_data.py
@@ -50,7 +50,7 @@ def unpack():
 
 
 def main():
-    with open(WORTSCHATZ_DICT_PATH, "r") as langs:
+    with open(WORTSCHATZ_DICT_PATH, "r", encoding="utf-8") as langs:
         languages = json.load(langs)
 
     # Hack for repeatedly attempting to download Wortschatz data

--- a/data/frequencies/merge.py
+++ b/data/frequencies/merge.py
@@ -20,7 +20,7 @@ def rewrite_wikipron_tsv(
     try:
         # This is written to be run after remove_duplicates_and_split.sh
         # and retain sorted order.
-        with open(file_to_target, "r") as wiki_file:
+        with open(file_to_target, "r", encoding="utf-8") as wiki_file:
             wiki_tsv = csv.reader(
                 wiki_file, delimiter="\t", quoting=csv.QUOTE_NONE
             )
@@ -46,7 +46,7 @@ def rewrite_wikipron_tsv(
 
 
 def main():
-    with open(WORTSCHATZ_DICT_PATH, "r") as langs:
+    with open(WORTSCHATZ_DICT_PATH, "r", encoding="utf-8") as langs:
         languages = json.load(langs)
 
     transcription = ["_phonetic.tsv", "_phonemic.tsv"]
@@ -57,7 +57,7 @@ def main():
         file_to_match = freq_file.rsplit("-", 1)[0]
         logging.info("Currently working on: %s", file_to_match)
 
-        with open(f"freq_tsvs/{freq_file}", "r") as tsv:
+        with open(f"freq_tsvs/{freq_file}", "r", encoding="utf-8") as tsv:
             frequencies_tsv = csv.reader(
                 tsv, delimiter="\t", quoting=csv.QUOTE_NONE
             )

--- a/data/src/codes.py
+++ b/data/src/codes.py
@@ -109,7 +109,7 @@ def _scrape_wiktionary_language_code(lang_title: str) -> str:
     session = requests_html.HTMLSession()
     language_page = session.get(
         f"https://en.wiktionary.org/wiki/Category:{lang_title}_language",
-        timeout=10
+        timeout=10,
     )
     return language_page.html.xpath(lang_code_selector)[0].text
 
@@ -129,20 +129,20 @@ def _check_language_code_against_wiki(
                 "listed as %r on Wiktionary",
                 language_code,
                 language_inferred,
-                language
+                language,
             )
 
 
 def main() -> None:
     new_languages = {}
     unmatched_languages = {}
-    with open(LANGUAGES_PATH, "r") as lang_source:
+    with open(LANGUAGES_PATH, "r", encoding="utf-8") as lang_source:
         prev_languages = json.load(lang_source)
 
-    with open(ISO_639_1_PATH, "r") as iso1_source:
+    with open(ISO_639_1_PATH, "r", encoding="utf-8") as iso1_source:
         iso639_1 = json.load(iso1_source)
 
-    with open(ISO_639_2_PATH, "r") as iso2_source:
+    with open(ISO_639_2_PATH, "r", encoding="utf-8") as iso2_source:
         iso639_2 = json.load(iso2_source)
 
     categories = _get_language_categories()
@@ -155,11 +155,11 @@ def main() -> None:
                 wiktionary_name.replace(" ", "_")
             )
             if wiktionary_code in iso639_1:
-                iso639_code = iso639_1[wiktionary_code]['code']
-                iso639_name = iso639_1[wiktionary_code]['name']
+                iso639_code = iso639_1[wiktionary_code]["code"]
+                iso639_name = iso639_1[wiktionary_code]["name"]
             elif wiktionary_code in iso639_2:
                 iso639_code = wiktionary_code
-                iso639_name = iso639_2[wiktionary_code]['name']
+                iso639_name = iso639_2[wiktionary_code]["name"]
             else:
                 # No match found for the Wiktionary code.
                 unmatched_languages[wiktionary_code] = {
@@ -187,9 +187,9 @@ def main() -> None:
                 }
             _check_language_code_against_wiki(iso639_code, wiktionary_name)
 
-    with open(LANGUAGES_PATH, "w") as sink:
+    with open(LANGUAGES_PATH, "w", encoding="utf-8") as sink:
         json.dump(new_languages, sink, indent=4, ensure_ascii=False)
-    with open(UNMATCHED_LANGUAGES_PATH, "w") as sink:
+    with open(UNMATCHED_LANGUAGES_PATH, "w", encoding="utf-8") as sink:
         json.dump(unmatched_languages, sink, indent=4, ensure_ascii=False)
 
 

--- a/data/src/generate_summary.py
+++ b/data/src/generate_summary.py
@@ -20,7 +20,9 @@ def _handle_wiki_name(
     name = language["wiktionary_name"]
     for modifier in modifiers:
         if modifier in language:
-            key = file_path[file_path.index("_") + 1 : file_path.rindex("_phone")]
+            key = file_path[
+                file_path.index("_") + 1 : file_path.rindex("_phone")
+            ]
             if not key:
                 logging.info(
                     "Failed to isolate key for %r modifier in %r",
@@ -36,7 +38,7 @@ def _handle_wiki_name(
 
 
 def main() -> None:
-    with open(LANGUAGES_PATH, "r") as source:
+    with open(LANGUAGES_PATH, "r", encoding="utf-8") as source:
         languages = json.load(source)
     readme_list = []
     languages_summary_list = []
@@ -46,7 +48,7 @@ def main() -> None:
         # Filters out README.md.
         if file_path.endswith(".md"):
             continue
-        with open(f"{path}/{file_path}", "r") as tsv:
+        with open(f"{path}/{file_path}", "r", encoding="utf-8") as tsv:
             num_of_entries = sum(1 for line in tsv)
         # Removes files with less than 100 entries.
         if num_of_entries < 100:
@@ -81,13 +83,13 @@ def main() -> None:
     languages_summary_list.sort(key=_wiki_name_and_transcription_level)
     readme_list.sort(key=_wiki_name_and_transcription_level)
     # Writes the TSV.
-    with open(LANGUAGES_SUMMARY_PATH, "w") as sink:
+    with open(LANGUAGES_SUMMARY_PATH, "w", encoding="utf-8") as sink:
         tsv_writer_object = csv.writer(
             sink, delimiter="\t", lineterminator="\n"
         )
         tsv_writer_object.writerows(languages_summary_list)
     # Writes the README.
-    with open(README_PATH, "w") as sink:
+    with open(README_PATH, "w", encoding="utf-8") as sink:
         print(
             "| Link | ISO 639-2 Code | ISO 639 Language Name "
             "| Wiktionary Language Name | Case-folding "

--- a/data/src/scrape.py
+++ b/data/src/scrape.py
@@ -20,7 +20,7 @@ from codes import LANGUAGES_PATH, LOGGING_PATH
 
 def _phones_reader(path: str) -> Iterator[str]:
     # Reads phones file.
-    with open(path, "r") as source:
+    with open(path, "r", encoding="utf-8") as source:
         for line in source:
             line = re.sub(r"\s*#.*$", "", line)  # Removes comments from line.
             yield line.rstrip()
@@ -46,12 +46,14 @@ def _call_scrape(
     tsv_filtered_path: str = "",
 ) -> None:
     for unused_retries in range(10):
-        with open(tsv_path, "w") as source:
+        with open(tsv_path, "w", encoding="utf-8") as source:
             try:
                 scrape_results = wikipron.scrape(config)
                 # Given phones, opens up a second tsv for scraping.
                 if phones_set:
-                    with open(tsv_filtered_path, "w") as source_filtered:
+                    with open(
+                        tsv_filtered_path, "w", encoding="utf-8"
+                    ) as source_filtered:
                         for (word, pron) in scrape_results:
                             line = f"{word}\t{pron}"
                             if _filter(word, pron, phones_set):
@@ -91,9 +93,7 @@ def _build_scraping_config(
     config_settings: Dict[str, Any], wiki_name: str, dialect_suffix: str = ""
 ) -> None:
     path_affix = f'../tsv/{config_settings["key"]}_{dialect_suffix}'
-    phones_path_affix = (
-        f"../phones/{config_settings['key']}_{dialect_suffix}"
-    )
+    phones_path_affix = f"../phones/{config_settings['key']}_{dialect_suffix}"
 
     # Configures phonemic TSV.
     phonemic_config = wikipron.Config(**config_settings)
@@ -143,7 +143,7 @@ def _build_scraping_config(
 
 
 def main(args: argparse.Namespace) -> None:
-    with open(LANGUAGES_PATH, "r") as source:
+    with open(LANGUAGES_PATH, "r", encoding="utf-8") as source:
         languages = json.load(source)
 
     codes = list(languages.keys())

--- a/data/src/split.py
+++ b/data/src/split.py
@@ -18,8 +18,8 @@ def _generalized_check(script: str, word: str) -> bool:
 def _iterate_through_file(
     tsv_path: str, output_path: str, unicode_script: str
 ) -> None:
-    with open(tsv_path, "r") as source:
-        with open(output_path, "w") as output_tsv:
+    with open(tsv_path, "r", encoding="utf-8") as source:
+        with open(output_path, "w", encoding="utf-8") as output_tsv:
             for line in source:
                 word = line.split("\t", 1)[0]
                 if _generalized_check(unicode_script, word):
@@ -28,10 +28,10 @@ def _iterate_through_file(
 
 def main() -> None:
     tsv_path = sys.argv[1]
-    with open("languages.json", "r") as lang_source:
+    with open("languages.json", "r", encoding="utf-8") as lang_source:
         languages = json.load(lang_source)
-    iso639_code = tsv_path[tsv_path.rindex("/") + 1:tsv_path.index("_")]
-    transcription_level = tsv_path[tsv_path.rindex("phone"):]
+    iso639_code = tsv_path[tsv_path.rindex("/") + 1 : tsv_path.index("_")]
+    transcription_level = tsv_path[tsv_path.rindex("phone") :]
     if "script" in languages[iso639_code]:
         lang = languages[iso639_code]
         # Hacky way of filtering out the already split scripts.

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ _VERSION = "1.1.0"
 
 _THIS_DIR = os.path.dirname(os.path.realpath(__file__))
 
-with open(os.path.join(_THIS_DIR, "README.md")) as f:
+with open(os.path.join(_THIS_DIR, "README.md"), encoding="utf-8") as f:
     _LONG_DESCRIPTION = f.read().strip()
 
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -9,7 +9,10 @@ _REPO_DIR = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
 
 def test_version_number_match_with_changelog():
     """__version__ and CHANGELOG.md match for the latest version number."""
-    changelog = open(os.path.join(_REPO_DIR, "CHANGELOG.md")).read()
+    changelog = open(
+        os.path.join(_REPO_DIR, "CHANGELOG.md"),
+        encoding="utf-8",
+    ).read()
     # latest version number in changelog = the 1st occurrence of '[x.y.z]'
     version_in_changelog = (
         re.search(r"\[\d+\.\d+\.\d+\]", changelog).group().strip("[]")


### PR DESCRIPTION
It looks like Windows users have encountered encodings --
they hit `UnicodeDecodeError: 'charmap' codec can't decode byte 0x81 in
position 2882: character maps to <undefined>` when pip installing
wikipron, the error triggered at setup.py.
While we're at it, we specify UTF-8 encoding for all open() calls
for text processing as well.

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
