### PR TITLE
Reorganize changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,86 +10,105 @@ Versioning](http://semver.org/spec/v2.0.0.html).
 Unreleased
 ----------
 
-### Added
--   Adds two Vietnamese dialects to `languages.json`. (\#139)
--   Adds whitelisting capabilities to `postprocess`. (\#152)
--   Adds whitelists for Dutch, English, Greek, Latin, Korean, and Spanish.
+### Under `data/`
+
+#### Added
+
+-   Added whitelisting capabilities to `postprocess`. (\#152)
+-   Added whitelists for Dutch, English, Greek, Latin, Korean, and Spanish.
     (\#158, etc.)
--   Improves printing in the README table. (\#145)
--   Renames data directory `data`. (\#147)
 -   Logged dialect configuration if specified. (\#133)
--   Handled additional language codes. (\#132, \#148)
--   Added `--no-skip-spaces-word` and `--no-skip-spaces-pron` flag. (\#135)
 -   Added typing to big scrape code. (\#140)
 -   Added argparse to allow limiting 'big scrape' to individual languages
     with `--restriction` flag. (\#154)
--   Split `may` into Latin and Arabic files. (\#164)
--   Split `pan` into Gurmukhi and Shahmukhī. (\#169)
--   Split `uig` into Perso-Arabic and Cyrillic. (\#173)
--   Allowed ASCII apostrophes (0x27) in spellings. (\#172).
--   Only allowed Latin spellings in Maltese lexicon. (\#166).
--   Split `mon` into Cyrillic and Mongol Bichig (\#179).
--   Added Vietnamese extraction function. (\#181).
--   Modified pron selector in Latin extraction function. (\#183).
--   Merged whitelist.py into 'big scrape' script. src scrape.py now checks for
-    existence of whitelist file during scrape to create second filtered TSV.
-    New TSV placed under `tsv/\*\_filtered.tsv`. (\#154).
 -   Added Manchu (`mnc`). (\#185)
 -   Added Polabian (`pox`). (\#186)
--   Updated `generate_summary.py` to reflect presence of 'filtered' tsv. (\#154)
--   Imperial Aramaic (`arc`) split into three scripts properly. (\#187)
--   Added `--no-tone` flag. (\#188)
--   Flattened data directory structure. (\#194)
--   Updated Georgian (`geo`) to take advantage of upstream bot-based
-    consistency fixes. (\#138)
--   Fixes path issue with phonetic whitelisted files. (\#195)
--   Split `arm` into Eastern and Western dialects. (\#197)
--   Rescraped files with new whitelists. (\#199)
--   Updates logging statements for consistency. (\#196)
--   Adds `aar`, `bdq`, `jje`, and `lsi`. (\#202)
+-   Added `aar`, `bdq`, `jje`, and `lsi`. (\#202)
 -   Added `tyv` to `languagecodes.py` (\#203, \#205)
 -   Added `bcl`, `egl`, `izh`, `ltg`, `azg`, `kir` and `mga` to `languagecodes.py`. (\#205)
 -   Added `nep` to `languagecodes.py`. (\#206)
--   Split `ban` into Latin and Balinese scripts. (\#214)
--   Scrape and add Ingrian (`izh`). (\#215)
--   Split `kir` into Cyrillic and Arabic. (\#216)
--   Adds French phoneme list and filtered TSV file. (\#213, \#217)
--   Customized extractor and new scraped prons for `khb`. (\#219)
+-   Added Ingrian (`izh`). (\#215)
+-   Added French phoneme list and filtered TSV file. (\#213, \#217)
 -   Added Coriscan (`cos`). (\#222)
 -   Added Middle Korean (`okm`). (\#223)
 -   Added Middle Irish (`mga`). (\#224)
 -   Added Old Portuguese (`opt`). (\#225)
--   Adds `tests/test_data` directory containing two tests. (\#226)
--   Adds Serbo-Croatian phoneme list and filtered TSV files. (\#227)
+-   Added Serbo-Croatian phoneme list and filtered TSV files. (\#227)
 -   Added Tuvan (`tyv`). (\#228)
 -   Added Shan (`shn`) with custom extraction. (\#229)
--   Split Latin (`lat`) into its dialects. (\#233)
--   Added support for python 3.9 (\#236)
--   Adds black style formatting to `.circleci/config.yml`. (\#237)
 -   Added Northern Kurdish (`kmr`). (\#243)
 
-### Changed
+#### Changed
 
+-   Improved printing in the README table. (\#145)
+-   Renamed data directory `data`. (\#147)
+-   Split `may` into Latin and Arabic files. (\#164)
+-   Split `pan` into Gurmukhi and Shahmukhī. (\#169)
+-   Split `uig` into Perso-Arabic and Cyrillic. (\#173)
+-   Only allowed Latin spellings in Maltese lexicon. (\#166).
+-   Split `mon` into Cyrillic and Mongol Bichig (\#179).
+-   Merged whitelist.py into 'big scrape' script. src scrape.py now checks for
+    existence of whitelist file during scrape to create second filtered TSV.
+    New TSV placed under `tsv/\*\_filtered.tsv`. (\#154).
+-   Updated `generate_summary.py` to reflect presence of 'filtered' tsv. (\#154)
+-   Imperial Aramaic (`arc`) split into three scripts properly. (\#187)
+-   Flattened data directory structure. (\#194)
+-   Updated Georgian (`geo`) to take advantage of upstream bot-based
+    consistency fixes. (\#138)
+-   Split `arm` into Eastern and Western dialects. (\#197)
+-   Rescraped files with new whitelists. (\#199)
+-   Updated logging statements for consistency. (\#196)
 -   Renamed `.whitelist` file extension name as `.phones`. (\#207)
+-   Split `ban` into Latin and Balinese scripts. (\#214)
+-   Split `kir` into Cyrillic and Arabic. (\#216)
+-   Split Latin (`lat`) into its dialects. (\#233)
+
+#### Fixed
+
+-   Fixed path issue with phonetic whitelisted files. (\#195)
+
+### Under `wikipron/` and Elsewhere
+
+#### Added
+
+-   Added two Vietnamese dialects to `languages.json`. (\#139)
+-   Handled additional language codes. (\#132, \#148)
+-   Added `--no-skip-spaces-word` and `--no-skip-spaces-pron` flag. (\#135)
+-   Allowed ASCII apostrophes (0x27) in spellings. (\#172).
+-   Added Vietnamese extraction function. (\#181).
+-   Modified pron selector in Latin extraction function. (\#183).
+-   Added `--no-tone` flag. (\#188)
+-   Customized extractor and new scraped prons for `khb`. (\#219)
+-   Added `tests/test_data` directory containing two tests. (\#226)
+-   Added HTTP User-Agent header to API calls to Wiktionary. (\#234)
+-   Added support for python 3.9 (\#240)
+-   Added black style formatting to `.circleci/config.yml`. (\#242)
+
+#### Changed
+
 -   Specified UTF-8 encoding in handling text files. (\#221)
 -   Moved previous contents of `tests` into `tests/test_wikipron` (\#226)
--   updated the packages version numbers in requirements.txt to their latest according to PyPI (\#238)
+-   Updated the packages version numbers in requirements.txt to their latest according to PyPI (\#239)
 
-### Deprecated
-### Removed
+#### Deprecated
+
+#### Removed
+
 -   Moved Wiktionary querying functions from `test_languagecodes.py` to `codes.py` (\#205)
-### Fixed
-### Security
+
+#### Fixed
+
+#### Security
 
 [1.1.0] - 2020-03-03
 --------------------
 
-### Added
+#### Added
 
 -   Added the extraction function for Mandarin Chinese and its scraped data. (\#124)
 -   Integrated Wortschatz frequencies. (\#122)
 
-### Changed
+#### Changed
 
 -   Updated the Japanese extraction function and Japanese data. (\#129)
 -   Updated all scraped Wiktionary data and frequency data. (\#127, \#128)
@@ -97,14 +116,14 @@ Unreleased
 -   Moved small file removal to `generate_summary.py`. (\#119)
 -   Updated Russian data. (\#115)
 
-### Fixed
+#### Fixed
 
 -   Avoided and logged error in case of pron processing failure. (\#130)
 
 [1.0.0] - 2019-11-29
 ----------------------
 
-### Added
+#### Added
 
 -   Handled Japanese. (\#109, \#114)
 -   Handled Latin, for which the actual graphemes cannot be the Wiktionary
@@ -118,7 +137,7 @@ Unreleased
 -   Resolved Wiktionary language names for languages with at least 100
     pronunciation entries. (\#52, \#55)
 
-### Changed
+#### Changed
 
 -   Removed duplicate <word, pronunciation> pairs in the persisted data. (\#85, \#111, \#116)
 -   Split Welsh into Northern Wales and Southern dialects in the persisted data. (\#110)
@@ -126,13 +145,13 @@ Unreleased
 -   Split Serbo-Croatian into Cyrillic and Latin TSVs. (\#96)
 -   Generalized word and pronunciation extraction. (\#88)
 
-### Removed
+#### Removed
 
 -   Removed the timeout in smoke tests. (\#107)
 -   Removed the `output` option. (\#82)
 -   Removed the `require_dialect_label` option. (\#77)
 
-### Fixed
+#### Fixed
 
 -   Skipped pronunciations with a dash. (\#106)
 -   Skipped empty pronunciations in scraping. (\#59)
@@ -142,7 +161,7 @@ Unreleased
     `title="wikipedia:<language> phonology"` to cover previously unhandled
     languages (e.g., Estonian and Slovak). (\#49)
 
-### Security
+#### Security
 
 -   Avoided using `exec` to retrieve the version string. Used `pkg_resources`
     instead. (\#63)
@@ -150,7 +169,7 @@ Unreleased
 [0.1.1] - 2019-08-14
 ----------------------
 
-### Fixed
+#### Fixed
 
 -   Fixed import bug. (\#45)
 


### PR DESCRIPTION
This PR reorganizes the entries under "Unreleased" into "Under `data/`" and "Under `wikipron/` and Elsewhere". Using the directories as the classificatory criterion would hopefully make it easier to decide where an entry should go.

- [ ] [Not Applicable] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
