### PR TITLE
Add logging for dialect support for languages requiring custom extraction logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -83,6 +83,8 @@ Unreleased
 -   Added HTTP User-Agent header to API calls to Wiktionary. (\#234)
 -   Added support for python 3.9 (\#240)
 -   Added black style formatting to `.circleci/config.yml`. (\#242)
+-   Added logging for scraping a language with `--dialect` specified
+    that requires its custom extraction logic. (\#245)
 
 #### Changed
 

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -74,12 +74,12 @@ class Config:
         self.pron_xpath_selector: str = self._get_pron_xpath_selector(
             self.language, dialect
         )
+        self.dialect = dialect
         self.extract_word_pron: ExtractFunc = self._get_extract_word_pron(
             self.language
         )
         self.no_skip_spaces_word: bool = no_skip_spaces_word
         self.no_skip_spaces_pron: bool = no_skip_spaces_pron
-        self.dialect = dialect
 
     def _get_language(self, key) -> str:
         key = key.lower().strip()
@@ -174,6 +174,16 @@ class Config:
     def _get_extract_word_pron(self, language: str) -> ExtractFunc:
         try:
             extraction_function = EXTRACTION_FUNCTIONS[language]
+            if self.dialect:
+                logging.info(
+                    "%r requires custom logic to handle its data from "
+                    "Wiktionary. The dialect parameter, specified for "
+                    "%r, may or may not work as desired. "
+                    "If you notice any issues, please report them at "
+                    "https://github.com/kylebgorman/wikipron/issues.",
+                    language,
+                    self.dialect,
+                )
         except KeyError:
             extraction_function = extract_word_pron_default
 


### PR DESCRIPTION
This PR adds logging to warn about dialect support for languages that require custom extraction logic. As a test using Latin:

```
$ wikipron --dialect=classical lat
INFO: Language: 'Latin'
INFO: No cut-off date specified
INFO: Dialect(s): 'classical'
INFO: 'Latin' requires custom logic to handle its data from Wiktionary. The dialect parameter, specified for 'classical', may or may not work as desired. If you notice any issues, please report them at https://github.com/kylebgorman/wikipron/issues.
```

Closes #149.

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
