### PR TITLE
split tildes; resort

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Unreleased
 -   Added Shan (`shn`) with custom extraction. (\#229)
 -   Added Northern Kurdish (`kmr`). (\#243)
 -   Added a script to facilitate the creation of a `.phones` file. (\#246)
+-   Split multiple pronunciations joined by tilde in `eng_us_phonetic`
+
 
 #### Changed
 

--- a/data/tsv/eng_us_phonetic.tsv
+++ b/data/tsv/eng_us_phonetic.tsv
@@ -282,11 +282,9 @@ certification	s ɚ ɾ ɪ f ɪ k e ɪ ʃ ə n
 chance	t ʃʰ a n s
 chance	t ʃʰ e ə n s
 chance	t ʃʰ æ n s
-chance	t ʃʰ æ n s ~ t ʃʰ a n s
 chance	t ʃʰ ɐː n s
 chance	t ʃʰ ɑː n s
 chance	t ʃʰ ɛ ə n s
-chance	t ʃʰ ɛ ə n s ~ t ʃʰ e ə n s
 chaparral	ʃ æ p ɚ ɹ æ l
 chaparral	ʃ æ p ɚ ɹ ɛ l
 char	t ʃ ɑ ɹ
@@ -730,7 +728,9 @@ ipa	a ɪ pʰ iː e ɪ
 ireland	a ɪ ɚ l ə n d
 ireland	ä ɪ ɚ ɫ ɪ̈ n d
 ireland	ɑ ɪ ə l ə n d
-ireland	ɑ ɪ ɚ l ə n d ~ ʌ ɪ ɚ l ə n d ~ ə ɪ ɚ l ə n d
+ireland	ɑ ɪ ɚ l ə n d
+ireland	ə ɪ ɚ l ə n d
+ireland	ʌ ɪ ɚ l ə n d
 it	ɪ̈ t
 italy	ɪ ɾ l̩ i
 italy	ɪ ɾ ə l i


### PR DESCRIPTION
- [X] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
