### PR TITLE
Negative flags are renamed to positive statements (#141)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -95,7 +95,7 @@ Unreleased
 
 #### Changed
 
--   renamed arguments to positive statements in `wikipron/config.py` and edited `_get_process_pron` function accordingly. (\#141)  
+-   Renamed arguments to positive statements in `wikipron/config.py` and edited `_get_process_pron` function accordingly. (\#141)  
 -   Changed testing values used in `tests/test_config.py` in order to accomodate the addition of positive flags. (\#141)
 -   Specified UTF-8 encoding in handling text files. (\#221)
 -   Moved previous contents of `tests` into `tests/test_wikipron` (\#226)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,6 +76,7 @@ Unreleased
 
 #### Added
 
+-   Added positive flags for stress, syllable boundaries, tones, segment to `cli.py`. (\#141)
 -   Added two Vietnamese dialects to `languages.json`. (\#139)
 -   Handled additional language codes. (\#132, \#148)
 -   Added `--no-skip-spaces-word` and `--no-skip-spaces-pron` flag. (\#135)
@@ -94,6 +95,8 @@ Unreleased
 
 #### Changed
 
+-   renamed arguments to positive statements in `wikipron/config.py` and edited `_get_process_pron` function accordingly. (\#141)  
+-   Changed testing values used in `tests/test_config.py` in order to accomodate the addition of positive flags. (\#141)
 -   Specified UTF-8 encoding in handling text files. (\#221)
 -   Moved previous contents of `tests` into `tests/test_wikipron` (\#226)
 -   Updated the packages version numbers in requirements.txt to their latest according to PyPI (\#239)

--- a/tests/test_wikipron/test_config.py
+++ b/tests/test_wikipron/test_config.py
@@ -26,66 +26,64 @@ def test_casefold(casefold, input_word, expected_word):
 
 
 @pytest.mark.parametrize(
-    "no_stress, no_syllable_boundaries, input_pron, expected_pron",
+    "stress, syllable_boundaries, input_pron, expected_pron",
     [
-        (True, True, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ ɡ w ɪ s t ɪ k s"),
-        (True, False, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ . ɡ w ɪ s . t ɪ k s"),
-        (False, True, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ ˈɡ w ɪ s t ɪ k s"),
-        (False, False, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ . ˈɡ w ɪ s . t ɪ k s"),
+        (False, False, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ ɡ w ɪ s t ɪ k s"),
+        (False, True, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ . ɡ w ɪ s . t ɪ k s"),
+        (True, False, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ ˈɡ w ɪ s t ɪ k s"),
+        (True, True, "lɪŋ.ˈɡwɪs.tɪks", "l ɪ ŋ . ˈɡ w ɪ s . t ɪ k s"),
         # GH-59: Prons with only stress or syllable boundaries are skipped.
-        (False, False, "ˈ", None),
-        (False, False, ".", None),
-        (False, False, "", None),
+        (True, True, "ˈ", None),
+        (True, True, ".", None),
+        (True, True, "", None),
     ],
 )
-def test_process_pron(
-    no_stress, no_syllable_boundaries, input_pron, expected_pron
-):
+def test_process_pron(stress, syllable_boundaries, input_pron, expected_pron):
     config = config_factory(
-        no_stress=no_stress, no_syllable_boundaries=no_syllable_boundaries
+        stress=stress, syllable_boundaries=syllable_boundaries
     )
     assert config.process_pron(input_pron) == expected_pron
 
 
 @pytest.mark.parametrize(
-    "no_segment, input_pron, expected_pron",
+    "segment, input_pron, expected_pron",
     [
-        (False, "lɛ̃.ɡɥis.tik", "l ɛ̃ . ɡ ɥ i s . t i k"),
-        (False, "kʰæt", "kʰ æ t"),
-        (False, "ad͡ʒisɐ̃w", "a d͡ʒ i s ɐ̃ w"),
-        (False, "ovoɫˈnʲɤ", "o v o ɫ ˈnʲ ɤ"),
+        (True, "lɛ̃.ɡɥis.tik", "l ɛ̃ . ɡ ɥ i s . t i k"),
+        (True, "kʰæt", "kʰ æ t"),
+        (True, "ad͡ʒisɐ̃w", "a d͡ʒ i s ɐ̃ w"),
+        (True, "ovoɫˈnʲɤ", "o v o ɫ ˈnʲ ɤ"),
         # GH-83: Challenging IPA tokenizations.
-        (False, "ˌæb.oʊˈmaɪ.sɪn", "ˌæ b . o ʊ ˈm a ɪ . s ɪ n"),
-        (False, "ʷoˈtɤu̯", "ʷo ˈt ɤ u̯"),
-        (False, "ⁿdaˈɽá.ma", "ⁿd a ˈɽ á . m a"),
-        (True, "lɛ̃.ɡɥis.tik", "lɛ̃.ɡɥis.tik"),
+        (True, "ˌæb.oʊˈmaɪ.sɪn", "ˌæ b . o ʊ ˈm a ɪ . s ɪ n"),
+        (True, "ʷoˈtɤu̯", "ʷo ˈt ɤ u̯"),
+        (True, "ⁿdaˈɽá.ma", "ⁿd a ˈɽ á . m a"),
+        (False, "lɛ̃.ɡɥis.tik", "lɛ̃.ɡɥis.tik"),
     ],
 )
-def test_no_segment(no_segment, input_pron, expected_pron):
-    config = config_factory(no_segment=no_segment)
+def test_segment(segment, input_pron, expected_pron):
+    config = config_factory(segment=segment)
     assert config.process_pron(input_pron) == expected_pron
 
 
 @pytest.mark.parametrize(
-    "no_tone, input_pron, expected_pron",
+    "tone, input_pron, expected_pron",
     [
-        (False, "aˈɓa.ɽé", "a ˈɓ a . ɽ é"),
-        (True, "aˈɓa.ɽé", "a ˈɓ a . ɽ e"),
+        (True, "aˈɓa.ɽé", "a ˈɓ a . ɽ é"),
+        (False, "aˈɓa.ɽé", "a ˈɓ a . ɽ e"),
         (
-            True,
+            False,
             "feɪ̯³⁵ʈ͡ʂaɪ̯³⁵kʰwaɪ̯⁵¹⁻⁵³lɤ⁵¹ʂweɪ̯²¹⁴⁻²¹⁽⁴⁾",
             "f e ɪ̯ ʈ͡ʂ a ɪ̯ kʰ w a ɪ̯ l ɤ ʂ w e ɪ̯",
         ),
         (
-            True,
+            False,
             "kra˨˩.duːk̚˨˩.ton˥˩.kʰaː˩˩˦",
             "k r a . d uː k̚ . t o n . kʰ aː",
         ),
-        (True, "aˈt͡ʃe.w⁽ᵝ⁾á", "a ˈt͡ʃ e . w ⁽ᵝ ⁾ a"),
+        (False, "aˈt͡ʃe.w⁽ᵝ⁾á", "a ˈt͡ʃ e . w ⁽ᵝ ⁾ a"),
     ],
 )
-def test_no_tone(no_tone, input_pron, expected_pron):
-    config = config_factory(no_tone=no_tone)
+def test_tone(tone, input_pron, expected_pron):
+    config = config_factory(tone=tone)
     assert config.process_pron(input_pron) == expected_pron
 
 

--- a/wikipron/cli.py
+++ b/wikipron/cli.py
@@ -23,14 +23,16 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--no-stress",
-        action="store_true",
-        help="Remove stress marks in pronunciations.",
+        "--stress",
+        default=True,
+        help="By default, stress marks are included in pronunciations."
+        "To remove them, set this flag to False.",
     )
     parser.add_argument(
-        "--no-syllable-boundaries",
-        action="store_true",
-        help="Remove syllable boundary marks in pronunciations.",
+        "--syllable-boundaries",
+        default=True,
+        help="By default, syllable boundary marks are included."
+        "To Remove them from pronunciations, set this flag to False.",
     )
     parser.add_argument(
         "--dialect",
@@ -63,15 +65,15 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
         ),
     )
     parser.add_argument(
-        "--no-segment",
-        action="store_true",
+        "--segment",
+        default=True,
         help=(
             "By default, the IPA pronunciation is segmented by whitespace and,"
             "to the extent possible, with a diacritic (either combining "
             "or modifier) immediately following the parent symbol. "
             'For example, "kʰæt" is segmented as "kʰ æ t", with kʰ '
             "conveniently segmented as an aspirated k for modeling purposes. "
-            "To disable such IPA segmentation, apply this flag."
+            "To disable such IPA segmentation, set this flag to False."
         ),
     )
     parser.add_argument(
@@ -85,9 +87,12 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
         help="Skip spaces in the transcription",
     )
     parser.add_argument(
-        "--no-tone",
-        action="store_true",
-        help="Remove tones in the transcription.",
+        "--tone",
+        default=True,
+        help=(
+            "By default, tones are included in pronunciations."
+            "To remove them, set this flag to False."
+        ),
     )
     return parser.parse_args(args)
 

--- a/wikipron/cli.py
+++ b/wikipron/cli.py
@@ -24,15 +24,29 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--stress",
+        action="store_true",
+        dest="stress",
         default=True,
-        help="By default, stress marks are included in pronunciations."
-        "To remove them, set this flag to False.",
+        help="Include stress marks in pronunciations.",
+    )
+    parser.add_argument(
+        "--no-stress",
+        action="store_false",
+        dest="stress",
+        help="Remove stress marks from pronunciations.",
     )
     parser.add_argument(
         "--syllable-boundaries",
+        action="store_true",
+        dest="syllable_boundaries",
         default=True,
-        help="By default, syllable boundary marks are included."
-        "To Remove them from pronunciations, set this flag to False.",
+        help="Include syllable boundary marks in pronunciations.",
+    )
+    parser.add_argument(
+        "--no-syllable-boundaries",
+        action="store_false",
+        dest="syllable_boundaries",
+        help="Remove syllable boundary marks from pronuncations.",
     )
     parser.add_argument(
         "--dialect",
@@ -66,14 +80,24 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--segment",
+        action="store_true",
+        dest="segment",
         default=True,
         help=(
-            "By default, the IPA pronunciation is segmented by whitespace and,"
+            "Segment the IPA pronunciation by whitespace and,"
             "to the extent possible, with a diacritic (either combining "
             "or modifier) immediately following the parent symbol. "
             'For example, "kʰæt" is segmented as "kʰ æ t", with kʰ '
             "conveniently segmented as an aspirated k for modeling purposes. "
-            "To disable such IPA segmentation, set this flag to False."
+        ),
+    )
+    parser.add_argument(
+        "--no-segment",
+        action="store_false",
+        dest="segment",
+        help=(
+            "To avoid segmenting the IPA pronunciation by whitespace,"
+            "apply this flag."
         ),
     )
     parser.add_argument(
@@ -88,11 +112,16 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
     )
     parser.add_argument(
         "--tone",
+        action="store_true",
+        dest="tone",
         default=True,
-        help=(
-            "By default, tones are included in pronunciations."
-            "To remove them, set this flag to False."
-        ),
+        help=("Include tones in pronunciations."),
+    )
+    parser.add_argument(
+        "--no-tone",
+        action="store_false",
+        dest="tone",
+        help=("Remove tones from pronunciations."),
     )
     return parser.parse_args(args)
 

--- a/wikipron/cli.py
+++ b/wikipron/cli.py
@@ -25,7 +25,6 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--stress",
         action="store_true",
-        dest="stress",
         default=True,
         help="Include stress marks in pronunciations.",
     )
@@ -38,7 +37,6 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--syllable-boundaries",
         action="store_true",
-        dest="syllable_boundaries",
         default=True,
         help="Include syllable boundary marks in pronunciations.",
     )
@@ -81,7 +79,6 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--segment",
         action="store_true",
-        dest="segment",
         default=True,
         help=(
             "Segment the IPA pronunciation by whitespace and,"
@@ -113,7 +110,6 @@ def _get_cli_args(args: List[str]) -> argparse.Namespace:
     parser.add_argument(
         "--tone",
         action="store_true",
-        dest="tone",
         default=True,
         help=("Include tones in pronunciations."),
     )

--- a/wikipron/config.py
+++ b/wikipron/config.py
@@ -54,20 +54,20 @@ class Config:
         *,
         key: str,
         casefold: bool = False,
-        no_stress: bool = False,
-        no_syllable_boundaries: bool = False,
+        stress: bool = True,
+        syllable_boundaries: bool = True,
         cut_off_date: Optional[str] = None,
         phonetic: bool = False,
         dialect: Optional[str] = None,
-        no_segment: bool = False,
-        no_tone: bool = False,
+        segment: bool = True,
+        tone: bool = True,
         no_skip_spaces_word: bool = False,
         no_skip_spaces_pron: bool = False,
     ):
         self.language: str = self._get_language(key)
         self.casefold: Callable[[Word], Word] = self._get_casefold(casefold)
         self.process_pron: Callable[[Pron], Pron] = self._get_process_pron(
-            no_stress, no_syllable_boundaries, no_segment, no_tone
+            stress, syllable_boundaries, segment, tone
         )
         self.cut_off_date: str = self._get_cut_off_date(cut_off_date)
         self.ipa_regex: str = _PHONES_REGEX if phonetic else _PHONEMES_REGEX
@@ -130,20 +130,20 @@ class Config:
 
     def _get_process_pron(
         self,
-        no_stress: bool,
-        no_syllable_boundaries: bool,
-        no_segment: bool,
-        no_tone: bool,
+        stress: bool,
+        syllable_boundaries: bool,
+        segment: bool,
+        tone: bool,
     ) -> Callable[[Pron], Pron]:
         processors = []
-        if no_stress:
+        if not stress:
             processors.append(functools.partial(re.sub, r"[ˈˌ]", ""))
-        if no_syllable_boundaries:
+        if not syllable_boundaries:
             processors.append(functools.partial(re.sub, r"\.", ""))
-        if no_tone:
+        if not tone:
             processors.append(functools.partial(re.sub, _PARENS_REGEX, ""))
             processors.append(functools.partial(re.sub, _TONES_REGEX, ""))
-        if not no_segment:
+        if segment:
             processors.append(
                 functools.partial(segments.Tokenizer(), ipa=True)
             )


### PR DESCRIPTION
This pull request is for #141 
Negative flags in `cli.py` are renamed to positive statements. In order to accommodate this change,` Wikipron/config.py` and `tests/test_wikipron/test_config.py` are also edited accordingly.

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
