### PR TITLE
Adds test for TSV splitting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,7 +66,7 @@ Unreleased
 -   Split `kir` into Cyrillic and Arabic. (\#216)
 -   Split Latin (`lat`) into its dialects. (\#233)
 -   Added MyPy coverage for `wikipron`, `tests` and `data` directories. (\#247)
--   Modified paths in `codes.py` and `scrape.py`. (\#251)
+-   Modified paths in `codes.py`, `scrape.py`, and `split.py`. (\#251, \#256)
 
 #### Fixed
 
@@ -91,6 +91,7 @@ Unreleased
 -   Added logging for scraping a language with `--dialect` specified
     that requires its custom extraction logic. (\#245)
 -   Improved CircleCI workflow with orbs. (\#249)
+-   Added `test_split.py` to `tests/test_data`. (\#256)
 
 #### Changed
 

--- a/data/src/codes.py
+++ b/data/src/codes.py
@@ -33,13 +33,16 @@ import requests
 import requests_html  # type: ignore
 import wikipron
 
-LANGUAGES_PATH = "languages.json"
-UNMATCHED_LANGUAGES_PATH = "unmatched_languages.json"
-LOGGING_PATH = "scraping.log"
-ISO_639_1_PATH = "iso639_1-to-iso639_2.json"
-ISO_639_2_PATH = "iso639_2.json"
+SRC_DIRECTORY = os.path.dirname(os.path.realpath(__file__))
+LANGUAGES_PATH = os.path.join(SRC_DIRECTORY, "languages.json")
+UNMATCHED_LANGUAGES_PATH = os.path.join(
+    SRC_DIRECTORY, "unmatched_languages.json"
+)
+LOGGING_PATH = os.path.join(SRC_DIRECTORY, "scraping.log")
+ISO_639_1_PATH = os.path.join(SRC_DIRECTORY, "iso639_1-to-iso639_2.json")
+ISO_639_2_PATH = os.path.join(SRC_DIRECTORY, "iso639_2.json")
 URL = "https://en.wiktionary.org/w/api.php"
-DATA_DIRECTORY = os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+DATA_DIRECTORY = os.path.dirname(SRC_DIRECTORY)
 README_PATH = os.path.join(DATA_DIRECTORY, "README.md")
 LANGUAGES_SUMMARY_PATH = os.path.join(DATA_DIRECTORY, "languages_summary.tsv")
 TSV_DIRECTORY_PATH = os.path.join(DATA_DIRECTORY, "tsv")

--- a/data/src/postprocess
+++ b/data/src/postprocess
@@ -8,7 +8,7 @@ main() {
         # Explicitly uses byte-wise comparison for sorting
         # rather than a locale-dependent comparison.
         LC_ALL=C sort -u -o "${TSV}" "${TSV}"
-        ./split.py "${TSV}"
+        ./split.py --tsv_path="${TSV}"
     done
 }
 

--- a/data/src/postprocess
+++ b/data/src/postprocess
@@ -8,7 +8,7 @@ main() {
         # Explicitly uses byte-wise comparison for sorting
         # rather than a locale-dependent comparison.
         LC_ALL=C sort -u -o "${TSV}" "${TSV}"
-        ./split.py --tsv_path="${TSV}"
+        ./split.py "${TSV}"
     done
 }
 

--- a/data/src/split.py
+++ b/data/src/split.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python
 
-import argparse
 import json
 import os
+import sys
 
 import regex  # type: ignore
 
@@ -28,8 +28,8 @@ def _iterate_through_file(
                     print(line.rstrip(), file=output_tsv)
 
 
-def main(args: argparse.Namespace) -> None:
-    tsv_path = args.tsv_path
+def main() -> None:
+    tsv_path = sys.argv[1]
     with open(LANGUAGES_PATH, "r", encoding="utf-8") as lang_source:
         languages = json.load(lang_source)
     iso639_code = tsv_path[tsv_path.rindex("/") + 1 : tsv_path.index("_")]
@@ -53,10 +53,4 @@ def main(args: argparse.Namespace) -> None:
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--tsv_path",
-        type=str,
-        required=True,
-    )
-    main(parser.parse_args())
+    main()

--- a/data/src/split.py
+++ b/data/src/split.py
@@ -1,10 +1,12 @@
 #!/usr/bin/env python
 
+import argparse
 import json
 import os
-import sys
 
 import regex  # type: ignore
+
+from data.src.codes import LANGUAGES_PATH, TSV_DIRECTORY_PATH
 
 
 def _generalized_check(script: str, word: str) -> bool:
@@ -26,9 +28,9 @@ def _iterate_through_file(
                     print(line.rstrip(), file=output_tsv)
 
 
-def main() -> None:
-    tsv_path = sys.argv[1]
-    with open("languages.json", "r", encoding="utf-8") as lang_source:
+def main(args: argparse.Namespace) -> None:
+    tsv_path = args.tsv_path
+    with open(LANGUAGES_PATH, "r", encoding="utf-8") as lang_source:
         languages = json.load(lang_source)
     iso639_code = tsv_path[tsv_path.rindex("/") + 1 : tsv_path.index("_")]
     transcription_level = tsv_path[tsv_path.rindex("phone") :]
@@ -41,7 +43,7 @@ def main() -> None:
                 return
         for script_prefix, unicode_script in lang["script"].items():
             output_path = (
-                f"../tsv/{iso639_code}_{script_prefix}_"
+                f"{TSV_DIRECTORY_PATH}/{iso639_code}_{script_prefix}_"
                 f"{transcription_level}"
             )
             _iterate_through_file(tsv_path, output_path, unicode_script)
@@ -51,4 +53,10 @@ def main() -> None:
 
 
 if __name__ == "__main__":
-    main()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--tsv_path",
+        type=str,
+        required=True,
+    )
+    main(parser.parse_args())

--- a/tests/test_data/test_split.py
+++ b/tests/test_data/test_split.py
@@ -16,7 +16,8 @@ SmokeTestScript = collections.namedtuple(
     "SmokeTestScript", ("script", "samples")
 )
 SmokeTestScript.__doc__ = """
-Represents a language to run a smoke test on.
+A script and a list of orthography samples to run
+a smoke test on.
 
 Parameters
 ----------
@@ -80,9 +81,9 @@ def _collect_scripts() -> Set[str]:
     scripts = set()
     with open(_LANGUAGES, "r") as source:
         languages = json.load(source)
-    for language in languages:
-        if "script" in languages[language]:
-            for _, unicode_script in languages[language]["script"].items():
+    for lang in languages:
+        if "script" in languages[lang]:
+            for unicode_script in languages[lang]["script"].values():
                 scripts.add(unicode_script)
     return scripts
 
@@ -98,10 +99,15 @@ def test_script_coverage(observed_scripts, known_scripts):
     for script in observed_scripts:
         assert (
             script in known_scripts
-        ), f"{script} must be included in _SCRIPTS."
+        ), f"{script} must be included in the smoke test."
 
 
 @pytest.mark.parametrize("smoke_test_script,", _SMOKE_TEST_LANGUAGES)
 def test_smoke_test_script(smoke_test_script):
-    for sample, val in smoke_test_script.samples:
-        assert _generalized_check(smoke_test_script.script, sample) == val
+    """Checks whether the scripts we'd like to split are appropriately handled
+    by the Unicode script property."""
+    for script_sample, predicted_truth_val in smoke_test_script.samples:
+        assert (
+            _generalized_check(smoke_test_script.script, script_sample)
+            == predicted_truth_val
+        )

--- a/tests/test_data/test_split.py
+++ b/tests/test_data/test_split.py
@@ -62,10 +62,16 @@ _SMOKE_TEST_LANGUAGES = [
     ),
     SmokeTestScript("Balinese", [("ᬰᬶᬮᬵ", True), ("ᬰнᬮᬰสุᬮᬵ", False)]),
     SmokeTestScript("Cyrillic", [("наиме", True), ("наиmе", False)]),
-    SmokeTestScript("Gurmukhi", [("ਲੂੰਬੜੀ", True), ("ੁ", True), ("ਲਬลੜੀ", False)]),
-    SmokeTestScript("Katakana", [("シニヨン", True), ("あいき", False), ("瀨", False)]),
+    SmokeTestScript(
+        "Gurmukhi", [("ਲੂੰਬੜੀ", True), ("ੁ", True), ("ਲਬลੜੀ", False)]
+    ),
+    SmokeTestScript(
+        "Katakana", [("シニヨン", True), ("あいき", False), ("瀨", False)]
+    ),
     SmokeTestScript("Imperial Aramaic", [("𐡀𐡅𐡓𐡔𐡋𐡌", True), ("𐡀ܒ𐡓𐡔𐡋𐡌", False)]),
-    SmokeTestScript("Latin", [("wikipron", True), ("ае", False), ("lịch", True)]),
+    SmokeTestScript(
+        "Latin", [("wikipron", True), ("ае", False), ("lịch", True)]
+    ),
     SmokeTestScript("Arabic", [("ژۇرنال", True), ("ژלرنال", False)]),
 ]
 

--- a/tests/test_data/test_split.py
+++ b/tests/test_data/test_split.py
@@ -16,7 +16,7 @@ SmokeTestScript = collections.namedtuple(
     "SmokeTestScript", ("script", "samples")
 )
 SmokeTestScript.__doc__ = """
-A script and a list of orthography samples to run
+A script and a list of orthographic samples to run
 a smoke test on.
 
 Parameters

--- a/tests/test_data/test_split.py
+++ b/tests/test_data/test_split.py
@@ -1,0 +1,101 @@
+import collections
+import json
+import pytest
+import os
+
+from typing import Set
+
+from data.src.split import _generalized_check
+
+_REPO_DIR = os.path.dirname(
+    os.path.dirname(os.path.dirname(os.path.realpath(__file__)))
+)
+_LANGUAGES = os.path.join(_REPO_DIR, "data/src/languages.json")
+
+SmokeTestScript = collections.namedtuple(
+    "SmokeTestScript", ("script", "samples")
+)
+SmokeTestScript.__doc__ = """
+Represents a language to run a smoke test on.
+
+Parameters
+----------
+script : str
+    Unicode script name.
+samples : list
+    List of tuples containing samples of various scripts
+    and a boolean reflecting whether those samples are
+    within that Unicode script range.
+"""
+
+_SMOKE_TEST_LANGUAGES = [
+    SmokeTestScript(
+        "Han",
+        [
+            ("瀨尿蝦", True),
+            ("Mandarin", False),
+            ("กงสุล", False),
+            ("烈日x空", False),
+            ("た日當空", False),
+        ],
+    ),
+    SmokeTestScript(
+        "Hiragana",
+        [
+            ("あいきどう", True),
+            ("Lucas", False),
+            ("シミーズ", False),
+            ("あいかイらず", False),
+        ],
+    ),
+    SmokeTestScript(
+        "Hebrew",
+        [
+            ("עליתא", True),
+            ("мећава", False),
+            ("עלbתא", False),
+            ("πיתא", False),
+        ],
+    ),
+    SmokeTestScript(
+        "Syriac", [("ܐܒܝܕܘܬܐ", True), ("ܐܒܝܕאܬܐ", False), ("cܘܘl", False)]
+    ),
+    SmokeTestScript("Balinese", [("ᬰᬶᬮᬵ", True), ("ᬰнᬮᬰสุᬮᬵ", False)]),
+    SmokeTestScript("Cyrillic", [("наиме", True), ("наиmе", False)]),
+    SmokeTestScript("Gurmukhi", [("ਲੂੰਬੜੀ", True), ("ੁ", True), ("ਲਬลੜੀ", False)]),
+    SmokeTestScript("Katakana", [("シニヨン", True), ("あいき", False), ("瀨", False)]),
+    SmokeTestScript("Imperial Aramaic", [("𐡀𐡅𐡓𐡔𐡋𐡌", True), ("𐡀ܒ𐡓𐡔𐡋𐡌", False)]),
+    SmokeTestScript("Latin", [("wikipron", True), ("ае", False), ("lịch", True)]),
+    SmokeTestScript("Arabic", [("ژۇرنال", True), ("ژלرنال", False)]),
+]
+
+
+def _collect_scripts() -> Set[str]:
+    scripts = set()
+    with open(_LANGUAGES, "r") as source:
+        languages = json.load(source)
+    for language in languages:
+        if "script" in languages[language]:
+            for _, unicode_script in languages[language]["script"].items():
+                scripts.add(unicode_script)
+    return scripts
+
+
+@pytest.mark.parametrize(
+    "observed_scripts, known_scripts",
+    [(_collect_scripts(), [lang.script for lang in _SMOKE_TEST_LANGUAGES])],
+)
+def test_script_coverage(observed_scripts, known_scripts):
+    """All scripts added to languages.json must be
+    included in the smoke test.
+    """
+    for script in observed_scripts:
+        assert (
+            script in known_scripts
+        ), f"{script} must be included in _SCRIPTS."
+
+
+@pytest.mark.parametrize("smoke_test_script,", _SMOKE_TEST_LANGUAGES)
+def test_smoke_test_script(smoke_test_script):
+    for sample, val in smoke_test_script.samples:
+        assert _generalized_check(smoke_test_script.script, sample) == val


### PR DESCRIPTION
- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.

Another (experimental) test for the data side, modeled after `test_wikipron/test_scrape`. The goal of this test is just to make sure that whatever 'scripts' we add for languages in `languages.json` can be handled by `split.py` -- in particular by the `regex` package we use for identifying scripts.

I may have gone a bit over the top with the smoke test stuff, and I'm not confident I'm using it correctly, so feel free to send me back to the drawing board on this one. 
(I'll be busy most of tomorrow and won't be able to respond to comments until the evening.)