### PR TITLE
[yue] Handle Cantonese for scraping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -105,6 +105,7 @@ Unreleased
     that requires its custom extraction logic. (\#245)
 -   Improved CircleCI workflow with orbs. (\#249)
 -   Added `test_split.py` to `tests/test_data`. (\#256)
+-   Handled Cantonese for scraping. (\#277)
 
 #### Changed
 

--- a/tests/test_wikipron/test_scrape.py
+++ b/tests/test_wikipron/test_scrape.py
@@ -41,6 +41,7 @@ _SMOKE_TEST_LANGUAGES = [
     SmokeTestLanguage("cmn", "Chinese", {}),
     # Vietnamese data is mostly phonetic transcription.
     SmokeTestLanguage("vie", "Vietnamese", {"phonetic": True}),
+    SmokeTestLanguage("yue", "Cantonese", {}),
 ]
 
 

--- a/wikipron/extract/__init__.py
+++ b/wikipron/extract/__init__.py
@@ -6,11 +6,13 @@ from wikipron.extract.khb import extract_word_pron_lu
 from wikipron.extract.shn import extract_word_pron_shan
 from wikipron.extract.tha import extract_word_pron_thai
 from wikipron.extract.vie import extract_word_pron_vie
+from wikipron.extract.yue import extract_word_pron_yue
 
 
 # All extraction functions must have the exact same function signature.
 # The key has to be the language name used by Wiktionary.
 EXTRACTION_FUNCTIONS = {
+    "Cantonese": extract_word_pron_yue,
     "Chinese": extract_word_pron_cmn,
     "Japanese": extract_word_pron_jpn,
     "Khmer": extract_word_pron_khmer,

--- a/wikipron/extract/yue.py
+++ b/wikipron/extract/yue.py
@@ -13,6 +13,10 @@ if typing.TYPE_CHECKING:
     from wikipron.typing import Iterator, Word, Pron, WordPronPair
 
 
+# The last bit of //ul//li[small[i[a[@title="w:Standard Cantonese"]]]]
+# is needed because some Cantonese entries have pronunciation info for
+# multiple dialects (Standard Cantonese, Taishanese, etc.), and we need
+# to specifically target Standard Cantonese.
 _PRON_XPATH_TEMPLATE = """
     //div[@class="vsHide"]
         //ul

--- a/wikipron/extract/yue.py
+++ b/wikipron/extract/yue.py
@@ -1,0 +1,36 @@
+"""Word and pron extraction for Cantonese."""
+
+import itertools
+import typing
+
+import requests_html
+
+from wikipron.extract.default import yield_pron, IPA_XPATH_SELECTOR
+
+
+if typing.TYPE_CHECKING:
+    from wikipron.config import Config
+    from wikipron.typing import Iterator, Word, Pron, WordPronPair
+
+
+_PRON_XPATH_TEMPLATE = """
+    //div[@class="vsHide"]
+        //ul
+            //li[a[@title="w:Cantonese"]]
+                //ul//li[small[i[a[@title="w:Standard Cantonese"]]]]
+"""
+
+
+def yield_yue_pron(
+    request: requests_html, config: "Config"
+) -> "Iterator[Pron]":
+    for li_container in request.html.xpath(_PRON_XPATH_TEMPLATE):
+        yield from yield_pron(li_container, IPA_XPATH_SELECTOR, config)
+
+
+def extract_word_pron_yue(
+    word: "Word", request: requests_html, config: "Config"
+) -> "Iterator[WordPronPair]":
+    words = itertools.repeat(word)
+    prons = yield_yue_pron(request, config)
+    yield from zip(words, prons)

--- a/wikipron/scrape.py
+++ b/wikipron/scrape.py
@@ -56,15 +56,27 @@ def _scrape_once(data, config: Config) -> Iterator[WordPronPair]:
 
         for word, pron in config.extract_word_pron(title, request, config):
             # Pronunciation processing is done in NFD-space;
-            # we convert back to NFC aftewards.
+            # we convert back to NFC afterwards.
             normalized_pron = unicodedata.normalize("NFC", pron)
             # 'cast' is required 'normalize' doesn't return a 'Pron'
             yield word, cast(Pron, normalized_pron)
 
 
+def _language_name_for_scraping(language):
+    """Handle cases where X is under a "macrolanguage" on Wiktionary.
+
+    So far, only the Chinese languages necessitate this helper function.
+    We'll keep this function as simple as possible, until it becomes too
+    complicated and requires refactoring.
+    """
+    return "Chinese" if language == "Cantonese" else language
+
+
 def scrape(config: Config) -> Iterator[WordPronPair]:
     """Scrapes with a given configuration."""
-    category = _CATEGORY_TEMPLATE.format(language=config.language)
+    category = _CATEGORY_TEMPLATE.format(
+        language=_language_name_for_scraping(config.language)
+    )
     requests_params = {
         "action": "query",
         "format": "json",


### PR DESCRIPTION
This PR adds the Cantonese-specific extraction functions; these changes are very similar to #124 for Mandarin Chinese. 

This is part of #57, but does not fully resolve it. For reasons I have yet to understand better, I wasn't able to scrape for the Cantonese data. I triggered the scraping run with `./data/src/scrape.py --restriction=yue`, but kept getting `Exception detected while scraping: 'yue', '/Users/jacksonlee/repos/wikipron/data/tsv/yue_phonemic.tsv', ''` several times from the log after hours of scraping. It looks like the TSV file `data/tsv/yue_phonemic.tsv` was being filled, but only up to about a thousand or so entries, and then the scraping restarted by wiping this TSV file clean and showing that log line. Not entirely sure yet, but this is possibly related to #253 regarding rate limit etc.

These changes work for Cantonese as I've verified with the command `wikipron yue`. I thought I should get them checked in first, even though the TSV data isn't available yet.

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
