### PR TITLE
[kpv] Komi-Zyrian scraped.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Unreleased
 -   Enforced final newlines. (\#387)
 -   Adds all UniMorph languages to morphology. (\#393)
 -   Added `data/covering_grammar/lib/make_test_file.py` (\#396, \#399)
+-   Scraped Komi-Zyrian (`kpv`). (\#400)
 
 #### Changed
 

--- a/data/scrape/README.md
+++ b/data/scrape/README.md
@@ -1,10 +1,10 @@
 | Link | ISO 639-2 Code | ISO 639 Language Name | Wiktionary Language Name | Script | Dialect | Filtered | Phonetic/Phonemic | Case-folding | # of entries |
 | :---- | :----: | :----: | :----: | :----: | :----: | :----: | :----: | :----: | ----: |
-| [TSV](tsv/ady_cyrl_phonetic_filtered.tsv) | ady | Adygei; Adyghe | Adyghe | Cyrillic |  | True | Phonetic | True | 4,895 |
 | [TSV](tsv/ady_cyrl_phonetic.tsv) | ady | Adygei; Adyghe | Adyghe | Cyrillic |  | False | Phonetic | True | 5,123 |
+| [TSV](tsv/ady_cyrl_phonetic_filtered.tsv) | ady | Adygei; Adyghe | Adyghe | Cyrillic |  | True | Phonetic | True | 4,895 |
 | [TSV](tsv/aar_latn_phonemic.tsv) | aar | Afar | Afar | Latin |  | False | Phonemic | True | 715 |
-| [TSV](tsv/afr_latn_phonemic.tsv) | afr | Afrikaans | Afrikaans | Latin |  | False | Phonemic | True | 1,685 |
 | [TSV](tsv/afr_latn_phonemic_filtered.tsv) | afr | Afrikaans | Afrikaans | Latin |  | True | Phonemic | True | 1,659 |
+| [TSV](tsv/afr_latn_phonemic.tsv) | afr | Afrikaans | Afrikaans | Latin |  | False | Phonemic | True | 1,685 |
 | [TSV](tsv/afr_latn_phonetic.tsv) | afr | Afrikaans | Afrikaans | Latin |  | False | Phonetic | True | 121 |
 | [TSV](tsv/alb_latn_phonemic.tsv) | alb | Albanian | Albanian | Latin |  | False | Phonemic | True | 1,450 |
 | [TSV](tsv/alb_latn_phonetic.tsv) | alb | Albanian | Albanian | Latin |  | False | Phonetic | True | 823 |
@@ -37,11 +37,11 @@
 | [TSV](tsv/pcc_latn_phonemic.tsv) | pcc | Bouyei | Bouyei | Latin |  | False | Phonemic | True | 105 |
 | [TSV](tsv/bre_latn_phonemic.tsv) | bre | Breton | Breton | Latin |  | False | Phonemic | True | 495 |
 | [TSV](tsv/kxd_latn_phonemic.tsv) | kxd | Brunei | Brunei Malay | Latin |  | False | Phonemic | True | 346 |
-| [TSV](tsv/bul_cyrl_phonemic_filtered.tsv) | bul | Bulgarian | Bulgarian | Cyrillic |  | True | Phonemic | True | 31,782 |
 | [TSV](tsv/bul_cyrl_phonemic.tsv) | bul | Bulgarian | Bulgarian | Cyrillic |  | False | Phonemic | True | 31,881 |
+| [TSV](tsv/bul_cyrl_phonemic_filtered.tsv) | bul | Bulgarian | Bulgarian | Cyrillic |  | True | Phonemic | True | 31,782 |
 | [TSV](tsv/bul_cyrl_phonetic.tsv) | bul | Bulgarian | Bulgarian | Cyrillic |  | False | Phonetic | True | 6,377 |
-| [TSV](tsv/bur_mymr_phonemic_filtered.tsv) | bur | Burmese | Burmese | Myanmar |  | True | Phonemic | False | 4,631 |
 | [TSV](tsv/bur_mymr_phonemic.tsv) | bur | Burmese | Burmese | Myanmar |  | False | Phonemic | False | 4,636 |
+| [TSV](tsv/bur_mymr_phonemic_filtered.tsv) | bur | Burmese | Burmese | Myanmar |  | True | Phonemic | False | 4,631 |
 | [TSV](tsv/yue_hani_phonemic.tsv) | yue | Yue Chinese | Cantonese | Han |  | False | Phonemic | False | 87,378 |
 | [TSV](tsv/crx_cans_phonemic.tsv) | crx | Carrier | Carrier | Canadian Aboriginal |  | False | Phonemic | False | 175 |
 | [TSV](tsv/cat_latn_phonemic.tsv) | cat | Catalan; Valencian | Catalan | Latin |  | False | Phonemic | True | 55,829 |
@@ -70,12 +70,12 @@
 | [TSV](tsv/lwl_thai_phonemic.tsv) | lwl | Eastern Lawa | Eastern Lawa | Thai |  | False | Phonemic | False | 253 |
 | [TSV](tsv/arz_arab_phonemic.tsv) | arz | Egyptian Arabic | Egyptian Arabic | Arabic |  | False | Phonemic | False | 113 |
 | [TSV](tsv/egy_latn_phonemic.tsv) | egy | Egyptian (Ancient) | Egyptian | Latin |  | False | Phonemic | False | 3,403 |
-| [TSV](tsv/eng_latn_uk_phonemic_filtered.tsv) | eng | English | English | Latin | UK, Received Pronunciation | True | Phonemic | True | 60,422 |
-| [TSV](tsv/eng_latn_us_phonemic_filtered.tsv) | eng | English | English | Latin | US, General American | True | Phonemic | True | 57,230 |
 | [TSV](tsv/eng_latn_us_phonemic.tsv) | eng | English | English | Latin | US, General American | False | Phonemic | True | 58,072 |
+| [TSV](tsv/eng_latn_us_phonemic_filtered.tsv) | eng | English | English | Latin | US, General American | True | Phonemic | True | 57,230 |
 | [TSV](tsv/eng_latn_uk_phonemic.tsv) | eng | English | English | Latin | UK, Received Pronunciation | False | Phonemic | True | 61,173 |
-| [TSV](tsv/eng_latn_us_phonetic.tsv) | eng | English | English | Latin | US, General American | False | Phonetic | True | 1,633 |
+| [TSV](tsv/eng_latn_uk_phonemic_filtered.tsv) | eng | English | English | Latin | UK, Received Pronunciation | True | Phonemic | True | 60,422 |
 | [TSV](tsv/eng_latn_uk_phonetic.tsv) | eng | English | English | Latin | UK, Received Pronunciation | False | Phonetic | True | 1,284 |
+| [TSV](tsv/eng_latn_us_phonetic.tsv) | eng | English | English | Latin | US, General American | False | Phonetic | True | 1,633 |
 | [TSV](tsv/epo_latn_phonemic.tsv) | epo | Esperanto | Esperanto | Latin |  | False | Phonemic | True | 14,990 |
 | [TSV](tsv/est_latn_phonemic.tsv) | est | Estonian | Estonian | Latin |  | False | Phonemic | True | 429 |
 | [TSV](tsv/ewe_latn_phonemic.tsv) | ewe | Ewe | Ewe | Latin |  | False | Phonemic | True | 120 |
@@ -89,8 +89,8 @@
 | [TSV](tsv/glg_latn_phonemic.tsv) | glg | Galician | Galician | Latin |  | False | Phonemic | True | 4,887 |
 | [TSV](tsv/glg_latn_phonetic.tsv) | glg | Galician | Galician | Latin |  | False | Phonetic | True | 1,670 |
 | [TSV](tsv/kld_latn_phonemic.tsv) | kld | Gamilaraay | Gamilaraay | Latin |  | False | Phonemic | True | 454 |
-| [TSV](tsv/geo_geor_phonemic_filtered.tsv) | geo | Georgian | Georgian | Georgian |  | True | Phonemic | False | 15,123 |
 | [TSV](tsv/geo_geor_phonemic.tsv) | geo | Georgian | Georgian | Georgian |  | False | Phonemic | False | 15,124 |
+| [TSV](tsv/geo_geor_phonemic_filtered.tsv) | geo | Georgian | Georgian | Georgian |  | True | Phonemic | False | 15,123 |
 | [TSV](tsv/ger_latn_phonemic.tsv) | ger | German | German | Latin |  | False | Phonemic | True | 35,486 |
 | [TSV](tsv/ger_latn_phonemic_filtered.tsv) | ger | German | German | Latin |  | True | Phonemic | True | 34,145 |
 | [TSV](tsv/ger_latn_phonetic.tsv) | ger | German | German | Latin |  | False | Phonetic | True | 10,984 |
@@ -111,8 +111,8 @@
 | [TSV](tsv/hin_deva_phonemic.tsv) | hin | Hindi | Hindi | Devanagari |  | False | Phonemic | False | 11,296 |
 | [TSV](tsv/hin_deva_phonemic_filtered.tsv) | hin | Hindi | Hindi | Devanagari |  | True | Phonemic | False | 10,812 |
 | [TSV](tsv/hin_deva_phonetic.tsv) | hin | Hindi | Hindi | Devanagari |  | False | Phonetic | False | 9,563 |
-| [TSV](tsv/hun_latn_phonetic.tsv) | hun | Hungarian | Hungarian | Latin |  | False | Phonetic | True | 55,595 |
 | [TSV](tsv/hun_latn_phonetic_filtered.tsv) | hun | Hungarian | Hungarian | Latin |  | True | Phonetic | True | 55,533 |
+| [TSV](tsv/hun_latn_phonetic.tsv) | hun | Hungarian | Hungarian | Latin |  | False | Phonetic | True | 55,595 |
 | [TSV](tsv/hrx_latn_phonemic.tsv) | hrx | Hunsrik | Hunsrik | Latin |  | False | Phonemic | True | 1,545 |
 | [TSV](tsv/ice_latn_phonemic_filtered.tsv) | ice | Icelandic | Icelandic | Latin |  | True | Phonemic | True | 9,524 |
 | [TSV](tsv/ice_latn_phonemic.tsv) | ice | Icelandic | Icelandic | Latin |  | False | Phonemic | True | 9,578 |
@@ -126,13 +126,13 @@
 | [TSV](tsv/ina_latn_phonemic.tsv) | ina | Interlingua (International Auxiliary Language Association) | Interlingua | Latin |  | False | Phonemic | True | 265 |
 | [TSV](tsv/gle_latn_phonemic.tsv) | gle | Irish | Irish | Latin |  | False | Phonemic | True | 7,328 |
 | [TSV](tsv/gle_latn_phonetic.tsv) | gle | Irish | Irish | Latin |  | False | Phonetic | True | 1,575 |
-| [TSV](tsv/ita_latn_phonemic.tsv) | ita | Italian | Italian | Latin |  | False | Phonemic | True | 15,014 |
 | [TSV](tsv/ita_latn_phonemic_filtered.tsv) | ita | Italian | Italian | Latin |  | True | Phonemic | True | 14,476 |
+| [TSV](tsv/ita_latn_phonemic.tsv) | ita | Italian | Italian | Latin |  | False | Phonemic | True | 15,014 |
 | [TSV](tsv/ita_latn_phonetic.tsv) | ita | Italian | Italian | Latin |  | False | Phonetic | True | 6,075 |
 | [TSV](tsv/jam_latn_phonemic.tsv) | jam | Jamaican Creole English | Jamaican Creole | Latin |  | False | Phonemic | True | 147 |
 | [TSV](tsv/jpn_hira_phonetic_filtered.tsv) | jpn | Japanese | Japanese | Hiragana |  | True | Phonetic | False | 19,689 |
-| [TSV](tsv/jpn_kana_phonetic_filtered.tsv) | jpn | Japanese | Japanese | Katakana |  | True | Phonetic | False | 4,765 |
 | [TSV](tsv/jpn_hira_phonetic.tsv) | jpn | Japanese | Japanese | Hiragana |  | False | Phonetic | False | 19,930 |
+| [TSV](tsv/jpn_kana_phonetic_filtered.tsv) | jpn | Japanese | Japanese | Katakana |  | True | Phonetic | False | 4,765 |
 | [TSV](tsv/jpn_kana_phonetic.tsv) | jpn | Japanese | Japanese | Katakana |  | False | Phonetic | False | 5,268 |
 | [TSV](tsv/jje_hang_phonemic.tsv) | jje | Jejueo | Jeju | Hangul |  | False | Phonemic | False | 1,006 |
 | [TSV](tsv/kbd_cyrl_phonetic.tsv) | kbd | Kabardian | Kabardian | Cyrillic |  | False | Phonetic | True | 834 |
@@ -142,6 +142,7 @@
 | [TSV](tsv/khm_khmr_phonemic.tsv) | khm | Khmer | Khmer | Khmer |  | False | Phonemic | False | 3,411 |
 | [TSV](tsv/cnk_latn_phonemic.tsv) | cnk | Khumi Chin | Khumi Chin | Latin |  | False | Phonemic | True | 307 |
 | [TSV](tsv/kik_latn_phonemic.tsv) | kik | Kikuyu | Kikuyu | Latin |  | False | Phonemic | True | 1,129 |
+| [TSV](tsv/kpv_cyrl_phonemic.tsv) | kpv | Komi-Zyrian | Komi-Zyrian | Cyrillic |  | False | Phonemic | None | 321 |
 | [TSV](tsv/kor_hang_phonetic.tsv) | kor | Korean | Korean | Hangul |  | False | Phonetic | False | 16,402 |
 | [TSV](tsv/kor_hang_phonetic_filtered.tsv) | kor | Korean | Korean | Hangul |  | True | Phonetic | False | 14,141 |
 | [TSV](tsv/kir_cyrl_phonemic.tsv) | kir | Kirghiz | Kyrgyz | Cyrillic |  | False | Phonemic | True | 101 |
@@ -150,14 +151,14 @@
 | [TSV](tsv/lao_laoo_phonemic.tsv) | lao | Lao | Lao | Lao |  | False | Phonemic | False | 513 |
 | [TSV](tsv/lsi_latn_phonemic.tsv) | lsi | Lashi | Lashi | Latin |  | False | Phonemic | True | 300 |
 | [TSV](tsv/ltg_latn_phonetic.tsv) | ltg | Latgalian | Latgalian | Latin |  | False | Phonetic | True | 125 |
-| [TSV](tsv/lat_latn_clas_phonemic.tsv) | lat | Latin | Latin | Latin | Classical | False | Phonemic | True | 33,333 |
-| [TSV](tsv/lat_latn_eccl_phonemic.tsv) | lat | Latin | Latin | Latin | Ecclesiastical | False | Phonemic | True | 32,334 |
 | [TSV](tsv/lat_latn_vulg_phonemic.tsv) | lat | Latin | Latin | Latin | Vulgar | False | Phonemic | True | 508 |
+| [TSV](tsv/lat_latn_eccl_phonemic.tsv) | lat | Latin | Latin | Latin | Ecclesiastical | False | Phonemic | True | 32,334 |
+| [TSV](tsv/lat_latn_clas_phonemic.tsv) | lat | Latin | Latin | Latin | Classical | False | Phonemic | True | 33,333 |
 | [TSV](tsv/lat_latn_eccl_phonetic.tsv) | lat | Latin | Latin | Latin | Ecclesiastical | False | Phonetic | True | 31,750 |
-| [TSV](tsv/lat_latn_clas_phonetic.tsv) | lat | Latin | Latin | Latin | Classical | False | Phonetic | True | 32,715 |
 | [TSV](tsv/lat_latn_vulg_phonetic.tsv) | lat | Latin | Latin | Latin | Vulgar | False | Phonetic | True | 481 |
-| [TSV](tsv/lav_latn_phonetic.tsv) | lav | Latvian | Latvian | Latin |  | False | Phonetic | True | 1,291 |
+| [TSV](tsv/lat_latn_clas_phonetic.tsv) | lat | Latin | Latin | Latin | Classical | False | Phonetic | True | 32,715 |
 | [TSV](tsv/lav_latn_phonetic_filtered.tsv) | lav | Latvian | Latvian | Latin |  | True | Phonetic | True | 1,230 |
+| [TSV](tsv/lav_latn_phonetic.tsv) | lav | Latvian | Latvian | Latin |  | False | Phonetic | True | 1,291 |
 | [TSV](tsv/ayl_arab_phonemic.tsv) | ayl | Libyan Arabic | Libyan Arabic | Arabic |  | False | Phonemic | False | 157 |
 | [TSV](tsv/lij_latn_phonemic.tsv) | lij | Ligurian | Ligurian | Latin |  | False | Phonemic | True | 756 |
 | [TSV](tsv/lif_limb_phonemic.tsv) | lif | Limbu | Limbu | Limbu |  | False | Phonemic | False | 108 |
@@ -179,8 +180,8 @@
 | [TSV](tsv/may_arab_ara_phonemic.tsv) | may | Malay (macrolanguage) | Malay | Arabic |  | False | Phonemic | True | 628 |
 | [TSV](tsv/may_arab_ara_phonetic.tsv) | may | Malay (macrolanguage) | Malay | Arabic |  | False | Phonetic | True | 220 |
 | [TSV](tsv/may_latn_phonetic.tsv) | may | Malay (macrolanguage) | Malay | Latin |  | False | Phonetic | True | 444 |
-| [TSV](tsv/mlt_latn_phonemic.tsv) | mlt | Maltese | Maltese | Latin |  | False | Phonemic | True | 4,609 |
 | [TSV](tsv/mlt_latn_phonemic_filtered.tsv) | mlt | Maltese | Maltese | Latin |  | True | Phonemic | True | 4,035 |
+| [TSV](tsv/mlt_latn_phonemic.tsv) | mlt | Maltese | Maltese | Latin |  | False | Phonemic | True | 4,609 |
 | [TSV](tsv/mnc_mong_phonetic.tsv) | mnc | Manchu | Manchu | Mongolian |  | False | Phonetic | False | 890 |
 | [TSV](tsv/glv_latn_phonemic.tsv) | glv | Manx | Manx | Latin |  | False | Phonemic | True | 202 |
 | [TSV](tsv/glv_latn_phonetic.tsv) | glv | Manx | Manx | Latin |  | False | Phonetic | True | 125 |
@@ -244,21 +245,21 @@
 | [TSV](tsv/pms_latn_phonemic.tsv) | pms | Piemontese | Piedmontese | Latin |  | False | Phonemic | True | 732 |
 | [TSV](tsv/ppl_latn_phonemic.tsv) | ppl | Pipil | Pipil | Latin |  | False | Phonemic | True | 263 |
 | [TSV](tsv/pjt_latn_phonetic.tsv) | pjt | Pitjantjatjara | Pitjantjatjara | Latin |  | False | Phonetic | True | 125 |
-| [TSV](tsv/crk_cans_phonemic.tsv) | crk | Plains Cree | Plains Cree | Canadian Aboriginal |  | False | Phonemic | True | 152 |
 | [TSV](tsv/crk_latn_phonemic.tsv) | crk | Plains Cree | Plains Cree | Latin |  | False | Phonemic | True | 193 |
+| [TSV](tsv/crk_cans_phonemic.tsv) | crk | Plains Cree | Plains Cree | Canadian Aboriginal |  | False | Phonemic | True | 152 |
 | [TSV](tsv/pbv_latn_phonemic.tsv) | pbv | Pnar | Pnar | Latin |  | False | Phonemic | True | 101 |
 | [TSV](tsv/pox_latn_phonemic.tsv) | pox | Polabian | Polabian | Latin |  | False | Phonemic | True | 228 |
 | [TSV](tsv/pol_latn_phonemic.tsv) | pol | Polish | Polish | Latin |  | False | Phonemic | True | 71,863 |
-| [TSV](tsv/por_latn_po_phonemic_filtered.tsv) | por | Portuguese | Portuguese | Latin | Portugal | True | Phonemic | True | 9,800 |
-| [TSV](tsv/por_latn_po_phonemic.tsv) | por | Portuguese | Portuguese | Latin | Portugal | False | Phonemic | True | 10,122 |
 | [TSV](tsv/por_latn_bz_phonemic_filtered.tsv) | por | Portuguese | Portuguese | Latin | Brazil | True | Phonemic | True | 11,331 |
+| [TSV](tsv/por_latn_po_phonemic.tsv) | por | Portuguese | Portuguese | Latin | Portugal | False | Phonemic | True | 10,122 |
+| [TSV](tsv/por_latn_po_phonemic_filtered.tsv) | por | Portuguese | Portuguese | Latin | Portugal | True | Phonemic | True | 9,800 |
 | [TSV](tsv/por_latn_bz_phonemic.tsv) | por | Portuguese | Portuguese | Latin | Brazil | False | Phonemic | True | 11,489 |
-| [TSV](tsv/por_latn_bz_phonetic.tsv) | por | Portuguese | Portuguese | Latin | Brazil | False | Phonetic | True | 953 |
 | [TSV](tsv/por_latn_po_phonetic.tsv) | por | Portuguese | Portuguese | Latin | Portugal | False | Phonetic | True | 312 |
+| [TSV](tsv/por_latn_bz_phonetic.tsv) | por | Portuguese | Portuguese | Latin | Brazil | False | Phonetic | True | 953 |
 | [TSV](tsv/pan_guru_phonemic.tsv) | pan | Panjabi | Punjabi | Gurmukhi |  | False | Phonemic | False | 139 |
 | [TSV](tsv/rum_latn_phonemic.tsv) | rum | Romanian; Moldavian; Moldovan | Romanian | Latin |  | False | Phonemic | True | 4,103 |
-| [TSV](tsv/rum_latn_phonetic_filtered.tsv) | rum | Romanian; Moldavian; Moldovan | Romanian | Latin |  | True | Phonetic | True | 6,271 |
 | [TSV](tsv/rum_latn_phonetic.tsv) | rum | Romanian; Moldavian; Moldovan | Romanian | Latin |  | False | Phonetic | True | 6,377 |
+| [TSV](tsv/rum_latn_phonetic_filtered.tsv) | rum | Romanian; Moldavian; Moldovan | Romanian | Latin |  | True | Phonetic | True | 6,271 |
 | [TSV](tsv/rus_cyrl_phonetic.tsv) | rus | Russian | Russian | Cyrillic |  | False | Phonetic | True | 402,586 |
 | [TSV](tsv/san_deva_phonemic.tsv) | san | Sanskrit | Sanskrit | Devanagari |  | False | Phonemic | False | 6,839 |
 | [TSV](tsv/san_deva_phonetic.tsv) | san | Sanskrit | Sanskrit | Devanagari |  | False | Phonetic | False | 673 |
@@ -268,10 +269,10 @@
 | [TSV](tsv/sco_latn_phonetic.tsv) | sco | Scots | Scots | Latin |  | False | Phonetic | True | 438 |
 | [TSV](tsv/gla_latn_phonemic.tsv) | gla | Gaelic; Scottish Gaelic | Scottish Gaelic | Latin |  | False | Phonemic | True | 1,362 |
 | [TSV](tsv/gla_latn_phonetic.tsv) | gla | Gaelic; Scottish Gaelic | Scottish Gaelic | Latin |  | False | Phonetic | True | 107 |
-| [TSV](tsv/hbs_latn_phonemic.tsv) | hbs | Serbo-Croatian | Serbo-Croatian | Latin |  | False | Phonemic | True | 23,827 |
 | [TSV](tsv/hbs_cyrl_phonemic_filtered.tsv) | hbs | Serbo-Croatian | Serbo-Croatian | Cyrillic |  | True | Phonemic | True | 22,543 |
-| [TSV](tsv/hbs_latn_phonemic_filtered.tsv) | hbs | Serbo-Croatian | Serbo-Croatian | Latin |  | True | Phonemic | True | 23,517 |
 | [TSV](tsv/hbs_cyrl_phonemic.tsv) | hbs | Serbo-Croatian | Serbo-Croatian | Cyrillic |  | False | Phonemic | True | 22,735 |
+| [TSV](tsv/hbs_latn_phonemic_filtered.tsv) | hbs | Serbo-Croatian | Serbo-Croatian | Latin |  | True | Phonemic | True | 23,517 |
+| [TSV](tsv/hbs_latn_phonemic.tsv) | hbs | Serbo-Croatian | Serbo-Croatian | Latin |  | False | Phonemic | True | 23,827 |
 | [TSV](tsv/shn_mymr_phonemic.tsv) | shn | Shan | Shan | Myanmar |  | False | Phonemic | False | 487 |
 | [TSV](tsv/scn_latn_phonemic.tsv) | scn | Sicilian | Sicilian | Latin |  | False | Phonemic | True | 855 |
 | [TSV](tsv/scn_latn_phonetic.tsv) | scn | Sicilian | Sicilian | Latin |  | False | Phonetic | True | 287 |
@@ -280,12 +281,12 @@
 | [TSV](tsv/slv_latn_phonemic_filtered.tsv) | slv | Slovenian | Slovene | Latin |  | True | Phonemic | True | 4,390 |
 | [TSV](tsv/slv_latn_phonemic.tsv) | slv | Slovenian | Slovene | Latin |  | False | Phonemic | True | 4,396 |
 | [TSV](tsv/ajp_arab_phonemic.tsv) | ajp | South Levantine Arabic | South Levantine Arabic | Arabic |  | False | Phonemic | False | 155 |
-| [TSV](tsv/spa_latn_la_phonemic.tsv) | spa | Spanish; Castilian | Spanish | Latin | Latin America | False | Phonemic | True | 48,718 |
-| [TSV](tsv/spa_latn_la_phonemic_filtered.tsv) | spa | Spanish; Castilian | Spanish | Latin | Latin America | True | Phonemic | True | 48,649 |
-| [TSV](tsv/spa_latn_ca_phonemic_filtered.tsv) | spa | Spanish; Castilian | Spanish | Latin | Castilian | True | Phonemic | True | 60,677 |
 | [TSV](tsv/spa_latn_ca_phonemic.tsv) | spa | Spanish; Castilian | Spanish | Latin | Castilian | False | Phonemic | True | 60,805 |
-| [TSV](tsv/spa_latn_la_phonetic.tsv) | spa | Spanish; Castilian | Spanish | Latin | Latin America | False | Phonetic | True | 41,854 |
+| [TSV](tsv/spa_latn_la_phonemic.tsv) | spa | Spanish; Castilian | Spanish | Latin | Latin America | False | Phonemic | True | 48,718 |
+| [TSV](tsv/spa_latn_ca_phonemic_filtered.tsv) | spa | Spanish; Castilian | Spanish | Latin | Castilian | True | Phonemic | True | 60,677 |
+| [TSV](tsv/spa_latn_la_phonemic_filtered.tsv) | spa | Spanish; Castilian | Spanish | Latin | Latin America | True | Phonemic | True | 48,649 |
 | [TSV](tsv/spa_latn_ca_phonetic.tsv) | spa | Spanish; Castilian | Spanish | Latin | Castilian | False | Phonetic | True | 52,190 |
+| [TSV](tsv/spa_latn_la_phonetic.tsv) | spa | Spanish; Castilian | Spanish | Latin | Latin America | False | Phonetic | True | 41,854 |
 | [TSV](tsv/srn_latn_phonemic.tsv) | srn | Sranan Tongo | Sranan Tongo | Latin |  | False | Phonemic | True | 162 |
 | [TSV](tsv/swe_latn_phonemic.tsv) | swe | Swedish | Swedish | Latin |  | False | Phonemic | True | 3,544 |
 | [TSV](tsv/swe_latn_phonetic.tsv) | swe | Swedish | Swedish | Latin |  | False | Phonetic | True | 222 |
@@ -303,28 +304,28 @@
 | [TSV](tsv/tib_tibt_phonemic.tsv) | tib | Tibetan | Tibetan | Tibetan |  | False | Phonemic | False | 1,875 |
 | [TSV](tsv/ton_latn_phonemic.tsv) | ton | Tonga (Tonga Islands) | Tongan | Latin |  | False | Phonemic | True | 154 |
 | [TSV](tsv/tur_latn_phonemic.tsv) | tur | Turkish | Turkish | Latin |  | False | Phonemic | True | 1,789 |
-| [TSV](tsv/tur_latn_phonetic.tsv) | tur | Turkish | Turkish | Latin |  | False | Phonetic | True | 2,043 |
 | [TSV](tsv/tur_latn_phonetic_filtered.tsv) | tur | Turkish | Turkish | Latin |  | True | Phonetic | True | 1,812 |
+| [TSV](tsv/tur_latn_phonetic.tsv) | tur | Turkish | Turkish | Latin |  | False | Phonetic | True | 2,043 |
 | [TSV](tsv/tuk_latn_phonemic.tsv) | tuk | Turkmen | Turkmen | Latin |  | False | Phonemic | True | 107 |
 | [TSV](tsv/tyv_cyrl_phonemic.tsv) | tyv | Tuvinian | Tuvan | Cyrillic |  | False | Phonemic | True | 462 |
 | [TSV](tsv/ukr_cyrl_phonetic.tsv) | ukr | Ukrainian | Ukrainian | Cyrillic |  | False | Phonetic | True | 6,148 |
 | [TSV](tsv/urd_arab_phonemic.tsv) | urd | Urdu | Urdu | Arabic |  | False | Phonemic | False | 1,063 |
 | [TSV](tsv/uig_arab_ara_phonemic.tsv) | uig | Uighur | Uyghur | Arabic |  | False | Phonemic | True | 260 |
-| [TSV](tsv/vie_latn_hanoi_phonetic_filtered.tsv) | vie | Vietnamese | Vietnamese | Latin | Hà Nội | True | Phonetic | True | 15,240 |
 | [TSV](tsv/vie_latn_hanoi_phonetic.tsv) | vie | Vietnamese | Vietnamese | Latin | Hà Nội | False | Phonetic | True | 15,240 |
-| [TSV](tsv/vie_latn_hue_phonetic_filtered.tsv) | vie | Vietnamese | Vietnamese | Latin | Huế | True | Phonetic | True | 15,236 |
-| [TSV](tsv/vie_latn_hcmc_phonetic_filtered.tsv) | vie | Vietnamese | Vietnamese | Latin | Hồ Chí Minh City | True | Phonetic | True | 14,537 |
 | [TSV](tsv/vie_latn_hue_phonetic.tsv) | vie | Vietnamese | Vietnamese | Latin | Huế | False | Phonetic | True | 15,239 |
 | [TSV](tsv/vie_latn_hcmc_phonetic.tsv) | vie | Vietnamese | Vietnamese | Latin | Hồ Chí Minh City | False | Phonetic | True | 15,237 |
+| [TSV](tsv/vie_latn_hanoi_phonetic_filtered.tsv) | vie | Vietnamese | Vietnamese | Latin | Hà Nội | True | Phonetic | True | 15,240 |
+| [TSV](tsv/vie_latn_hcmc_phonetic_filtered.tsv) | vie | Vietnamese | Vietnamese | Latin | Hồ Chí Minh City | True | Phonetic | True | 14,537 |
+| [TSV](tsv/vie_latn_hue_phonetic_filtered.tsv) | vie | Vietnamese | Vietnamese | Latin | Huế | True | Phonetic | True | 15,236 |
 | [TSV](tsv/vol_latn_phonemic.tsv) | vol | Volapük | Volapük | Latin |  | False | Phonemic | True | 363 |
 | [TSV](tsv/vol_latn_phonetic.tsv) | vol | Volapük | Volapük | Latin |  | False | Phonetic | True | 565 |
 | [TSV](tsv/wau_latn_phonemic.tsv) | wau | Waurá | Wauja | Latin |  | False | Phonemic | True | 152 |
-| [TSV](tsv/wel_latn_sw_phonemic_filtered.tsv) | wel | Welsh | Welsh | Latin | South Wales | True | Phonemic | True | 9,925 |
 | [TSV](tsv/wel_latn_nw_phonemic_filtered.tsv) | wel | Welsh | Welsh | Latin | North Wales | True | Phonemic | True | 8,473 |
+| [TSV](tsv/wel_latn_sw_phonemic_filtered.tsv) | wel | Welsh | Welsh | Latin | South Wales | True | Phonemic | True | 9,925 |
 | [TSV](tsv/wel_latn_nw_phonemic.tsv) | wel | Welsh | Welsh | Latin | North Wales | False | Phonemic | True | 8,530 |
 | [TSV](tsv/wel_latn_sw_phonemic.tsv) | wel | Welsh | Welsh | Latin | South Wales | False | Phonemic | True | 9,999 |
-| [TSV](tsv/wel_latn_nw_phonetic.tsv) | wel | Welsh | Welsh | Latin | North Wales | False | Phonetic | True | 561 |
 | [TSV](tsv/wel_latn_sw_phonetic.tsv) | wel | Welsh | Welsh | Latin | South Wales | False | Phonetic | True | 601 |
+| [TSV](tsv/wel_latn_nw_phonetic.tsv) | wel | Welsh | Welsh | Latin | North Wales | False | Phonetic | True | 561 |
 | [TSV](tsv/fry_latn_phonemic.tsv) | fry | Western Frisian | West Frisian | Latin |  | False | Phonemic | True | 977 |
 | [TSV](tsv/apw_latn_phonetic.tsv) | apw | Western Apache | Western Apache | Latin |  | False | Phonetic | True | 158 |
 | [TSV](tsv/mww_latn_phonemic.tsv) | mww | Hmong Daw | White Hmong | Latin |  | False | Phonemic | True | 322 |

--- a/data/scrape/lib/languages.json
+++ b/data/scrape/lib/languages.json
@@ -887,7 +887,11 @@
         "iso639_name": "Komi-Zyrian",
         "wiktionary_name": "Komi-Zyrian",
         "wiktionary_code": "kpv",
-        "casefold": null
+        "casefold": true,
+        "script": {
+            "latn": "Latin",
+            "cyrl": "Cyrillic"
+        }
     },
     "kok": {
         "iso639_name": "Konkani (macrolanguage)",

--- a/data/scrape/tsv/kpv_cyrl_phonemic.tsv
+++ b/data/scrape/tsv/kpv_cyrl_phonemic.tsv
@@ -1,0 +1,321 @@
+Ёма	j o m ɑ
+Изьва	i zʲ v ɑ
+Печора	p e t͡sʲ o r ɑ
+Россия	r o s sʲ i j ɑ
+Сыктыв	s ɨ k t ɨ v
+Эжва	e ʒ v ɑ
+агас	ɑ ɡ ɑ s
+аски	ɑ s k i
+аскомысь	ɑ s k o m ɨ sʲ
+асыв	ɑ s ɨ v
+баба	b ɑ b ɑ
+бадь	b ɑ dʲ
+бать	b ɑ tʲ
+бедь	b e dʲ
+берд	b e r d
+блюд	b lʲ u d
+бобув	b o b u v
+бон	b o n
+борд	b o r d
+булка	b u l k ɑ
+бус	b u s
+бутылка	b u t ɨ l k ɑ
+быг	b ɨ ɡ
+ва	v ɑ
+вад	v ɑ d
+вал	v ɑ l
+вежон	v e ʒ o n
+ветымын	v e t ɨ m ɨ n
+видз	v i d͡zʲ
+видзысь	v i d͡zʲ ɨ sʲ
+визув	v i z u v
+вина	v i n ɑ
+вины	v i n ɨ
+вис	v i s
+вичко	v i t͡sʲ k o
+виысь	v i ɨ sʲ
+во	v o
+водзир	v o d͡zʲ i r
+вож	v o ʒ
+воз	v o z
+вой	v o j
+вок	v o k
+воль	v o lʲ
+вон	v o n
+воськов	v o sʲ k o v
+вуг	v u ɡ
+вудж	v u d͡ʒ
+вуж	v u ʒ
+вуз	v u z
+выллюн	v ɨ l lʲ u n
+выльлун	v ɨ lʲ l u n
+вӧв	v ə v
+вӧр	v ə r
+вӧравны	v ə r ɑ v n ɨ
+вӧралысь	v ə r ɑ l ɨ sʲ
+вӧрк	v ə r k
+вӧт	v ə t
+гаг	ɡ ɑ ɡ
+гадь	ɡ ɑ dʲ
+геб	ɡ e b
+гез	ɡ e z
+гезъяс	ɡ e z j ɑ s
+гоб	ɡ o b
+гож	ɡ o ʒ
+горс	ɡ o r s
+горт	ɡ o r t
+грезд	ɡ r e z d
+гыж	ɡ ɨ ʒ
+гыр	ɡ ɨ r
+гырк	ɡ ɨ r k
+гыч	ɡ ɨ t͡sʲ
+гӧг	ɡ ə ɡ
+гӧнец	ɡ ə nʲ e t͡s
+гӧп	ɡ ə p
+гӧр	ɡ ə r
+гӧсть	ɡ ə s tʲ
+гӧстя	ɡ ə s tʲ ɑ
+дав	d ɑ v
+дворец	d v o r e t͡s
+джадж	d͡ʒ ɑ d͡ʒ
+джек	d͡ʒ e k
+джодж	d͡ʒ o d͡ʒ
+джын	d͡ʒ ɨ n
+дзоридз	d͡zʲ o r i d͡zʲ
+додь	d o dʲ
+доз	d o z
+дон	d o n
+дуль	d u lʲ
+ді	d i
+ен	j e n
+енэж	j e n e ʒ
+жель	ʒ e lʲ
+жыр	ʒ ɨ r
+жӧник	ʒ ə n i k
+зеп	z e p
+зоб	z o b
+зон	z o n
+зонка	z o n k ɑ
+зыр	z ɨ r
+зэр	z e r
+зі	z i
+зіб	z i b
+зӧр	z ə r
+и	i
+ид	i d
+идз	i d͡zʲ
+из	i z
+история	i s t o r i j ɑ
+йыв	j ɨ v
+йӧв	j ə v
+йӧз	j ə z
+йӧй	j ə j
+йӧюк	j ə j u k
+кад	k ɑ d
+канава	k ɑ n ɑ v ɑ
+кань	k ɑ nʲ
+кар	k ɑ r
+квайтымын	k v ɑ j t ɨ m ɨ n
+кев	k e v
+кер	k e r
+керка	k e r k ɑ
+ключ	k lʲ u t͡sʲ
+книга	k nʲ i ɡ ɑ
+ков	k o v
+коз	k o z
+козин	k o zʲ i n
+кок	k o k
+коль	k o lʲ
+кольк	k o lʲ k
+кор	k o r
+кос	k o s
+кось	k o sʲ
+куз	k u z
+кыв	k ɨ v
+кыдз	k ɨ d͡zʲ
+кыр	k ɨ r
+кырныш	k ɨ r n ɨ ʃ
+кытш	k ɨ t͡ʃ
+кӧв	k ə v
+кӧин	k ə i n
+кӧкъямыс	k ə k j ɑ m ɨ s
+кӧр	k ə r
+кӧрт	k ə r t
+кӧч	k ə t͡sʲ
+кӧчиль	k ə t͡sʲ i lʲ
+леденец	lʲ e dʲ e nʲ e t͡s
+лек	lʲ e k
+лов	l o v
+лоп	l o p
+лудік	l u d i k
+лук	l u k
+лун	l u n
+лыд	l ɨ d
+лым	l ɨ m
+лыс	l ɨ s
+льӧб	lʲ ə b
+льӧм	lʲ ə m
+лэбач	l e b ɑ t͡sʲ
+лӧдз	l ə d͡zʲ
+мам	m ɑ m
+мамук	m ɑ m u k
+манак	m ɑ n ɑ k
+марксизм	m ɑ r k sʲ i z m
+мек	m e k
+мел	m e l
+мог	m o ɡ
+мойд	m o j d
+море	m o r e
+морт	m o r t
+мортвиысь	m o r t v i ɨ sʲ
+мортсёйысь	m o r t sʲ o j ɨ sʲ
+му	m u
+мус	m u s
+мыльк	m ɨ lʲ k
+мыр	m ɨ r
+мыш	m ɨ ʃ
+мӧвп	m ə v p
+мӧс	m ə s
+мӧсвидзысь	m ə s vʲ i d͡zʲ ɨ sʲ
+нальк	n ɑ lʲ k
+народ	n ɑ r o d
+невеста	nʲ e v e s t ɑ
+нек	nʲ e k
+нелямын	nʲ e lʲ ɑ m ɨ n
+ним	nʲ i m
+нитш	nʲ i t͡ʃ
+ном	n o m
+ныв	n ɨ v
+нывка	n ɨ v k ɑ
+ныр	n ɨ r
+ньыв	nʲ ɨ v
+ньывк	nʲ ɨ v k
+ньӧв	nʲ ə v
+нэм	n e m
+нянь	nʲ ɑ nʲ
+нёль	nʲ o lʲ
+нӧб	n ə b
+нӧк	n ə k
+оз	o z
+ош	o ʃ
+пар	p ɑ r
+партия	p ɑ r tʲ i j ɑ
+пашкан	p ɑ ʃ k ɑ n
+пев	p e v
+петас	p e t ɑ s
+пи	p i
+пивиысь	p i v i ɨ sʲ
+пилот	pʲ i l o t
+письмӧ	p i sʲ m ə
+пиук	p i u k
+плӧтник	p l ə t n i k
+пож	p o ʒ
+поз	p o z
+пон	p o n
+поп	p o p
+пос	p o s
+преник	p rʲ e nʲ i k
+пруд	p r u d
+пу	p u
+пув	p u v
+пуд	p u d
+пуж	p u ʒ
+пур	p u r
+пызан	p ɨ z ɑ n
+пызь	p ɨ zʲ
+пыш	p ɨ ʃ
+пӧв	p ə v
+пӧк	p ə k
+пӧлтинник	p ə l t i nʲː i k
+пӧрт	p ə r t
+равнина	r ɑ v n i n ɑ
+рас	r ɑ s
+регыд	r e ɡ ɨ d
+рос	r o s
+руч	r u t͡sʲ
+ручиль	r u t͡sʲ i lʲ
+рысь	r ɨ sʲ
+рыт	r ɨ t
+рытыв	r ɨ t ɨ v
+сад	s ɑ d
+свод	s v o d
+сикт	sʲ i k t
+син	sʲ i n
+сир	sʲ i r
+сись	sʲ i sʲ
+сов	s o v
+сод	s o d
+сок	s o k
+сос	s o s
+судно	s u d n o
+сунис	s u nʲ i s
+сьӧла	sʲ ə l ɑ
+сьӧм	sʲ ə m
+сюв	sʲ u v
+сюр	sʲ u r
+сюрс	sʲ u r s
+сё	sʲ o
+сёйны	sʲ o j n ɨ
+сёйысь	sʲ o j ɨ sʲ
+сім	s i m
+сӧп	s ə p
+таб	t ɑ b
+таз	t ɑ z
+талун	t ɑ l u n
+тор	t o r
+тош	t o ʃ
+тув	t u v
+тулыс	t u l ɨ s
+тупыль	t u p ɨ lʲ
+тури	t u r i
+тшак	t͡ʃ ɑ k
+тшыг	t͡ʃ ɨ ɡ
+тшӧг	t͡ʃ ə ɡ
+ты	t ɨ
+тыв	t ɨ v
+тӧб	t ə b
+тӧв	t ə v
+тӧвар	t ə v ɑ r
+тӧлысь	t ə l ɨ sʲ
+ув	u v
+удж	u d͡ʒ
+ун	u n
+ус	u s
+учение	u t͡sʲ e n i j e
+учитель	u t͡sʲ i tʲ e lʲ
+чаг	t͡sʲ ɑ ɡ
+чаль	t͡sʲ ɑ lʲ
+чань	t͡sʲ ɑ nʲ
+челядь	t͡sʲ e lʲ ɑ dʲ
+черань	t͡sʲ e r ɑ nʲ
+чери	t͡sʲ e r i
+чипам	t͡sʲ i p ɑ m
+чирк	t͡ʃ i r k
+чож	t͡sʲ o ʒ
+чом	t͡ʃ o m
+чуж	t͡sʲ u ʒ
+чужӧм	t͡sʲ u ʒ ə m
+чунь	t͡sʲ u nʲ
+чуньяс	t͡sʲ u nʲ j ɑ s
+чышъян	t sʲ ɨ ʃ j ɑ n
+чӧд	t͡sʲ ə d
+шайт	ʃ ɑ j t
+шег	ʃ e ɡ
+школа	ʃ k o l ɑ
+шляпа	ʃ lʲ ɑ p ɑ
+шонді	ʃ o n d i
+шуд	ʃ u d
+щель	ʃ e lʲ
+ыб	ɨ b
+ывла	ɨ v l a
+ыж	ɨ ʒ
+эж	e ʒ
+энь	e nʲ
+энька	e nʲ k ɑ
+юр	j u r
+яг	j ɑ ɡ
+ёг	j o ɡ
+ӧні	ə n i
+ӧтувкан	ə t u v k ɑ n
+ӧш	ə ʃ
+ӧшинь	ə ʃ i nʲ

--- a/data/scrape/tsv_summary.tsv
+++ b/data/scrape/tsv_summary.tsv
@@ -1,8 +1,8 @@
-ady_cyrl_phonetic_filtered.tsv	ady	Adygei; Adyghe	Adyghe	Cyrillic		True	Phonetic	True	4895
 ady_cyrl_phonetic.tsv	ady	Adygei; Adyghe	Adyghe	Cyrillic		False	Phonetic	True	5123
+ady_cyrl_phonetic_filtered.tsv	ady	Adygei; Adyghe	Adyghe	Cyrillic		True	Phonetic	True	4895
 aar_latn_phonemic.tsv	aar	Afar	Afar	Latin		False	Phonemic	True	715
-afr_latn_phonemic.tsv	afr	Afrikaans	Afrikaans	Latin		False	Phonemic	True	1685
 afr_latn_phonemic_filtered.tsv	afr	Afrikaans	Afrikaans	Latin		True	Phonemic	True	1659
+afr_latn_phonemic.tsv	afr	Afrikaans	Afrikaans	Latin		False	Phonemic	True	1685
 afr_latn_phonetic.tsv	afr	Afrikaans	Afrikaans	Latin		False	Phonetic	True	121
 alb_latn_phonemic.tsv	alb	Albanian	Albanian	Latin		False	Phonemic	True	1450
 alb_latn_phonetic.tsv	alb	Albanian	Albanian	Latin		False	Phonetic	True	823
@@ -35,11 +35,11 @@ bcl_latn_phonemic.tsv	bcl	Central Bikol	Bikol Central	Latin		False	Phonemic	True
 pcc_latn_phonemic.tsv	pcc	Bouyei	Bouyei	Latin		False	Phonemic	True	105
 bre_latn_phonemic.tsv	bre	Breton	Breton	Latin		False	Phonemic	True	495
 kxd_latn_phonemic.tsv	kxd	Brunei	Brunei Malay	Latin		False	Phonemic	True	346
-bul_cyrl_phonemic_filtered.tsv	bul	Bulgarian	Bulgarian	Cyrillic		True	Phonemic	True	31782
 bul_cyrl_phonemic.tsv	bul	Bulgarian	Bulgarian	Cyrillic		False	Phonemic	True	31881
+bul_cyrl_phonemic_filtered.tsv	bul	Bulgarian	Bulgarian	Cyrillic		True	Phonemic	True	31782
 bul_cyrl_phonetic.tsv	bul	Bulgarian	Bulgarian	Cyrillic		False	Phonetic	True	6377
-bur_mymr_phonemic_filtered.tsv	bur	Burmese	Burmese	Myanmar		True	Phonemic	False	4631
 bur_mymr_phonemic.tsv	bur	Burmese	Burmese	Myanmar		False	Phonemic	False	4636
+bur_mymr_phonemic_filtered.tsv	bur	Burmese	Burmese	Myanmar		True	Phonemic	False	4631
 yue_hani_phonemic.tsv	yue	Yue Chinese	Cantonese	Han		False	Phonemic	False	87378
 crx_cans_phonemic.tsv	crx	Carrier	Carrier	Canadian Aboriginal		False	Phonemic	False	175
 cat_latn_phonemic.tsv	cat	Catalan; Valencian	Catalan	Latin		False	Phonemic	True	55829
@@ -68,12 +68,12 @@ dzo_tibt_phonemic.tsv	dzo	Dzongkha	Dzongkha	Tibetan		False	Phonemic	False	188
 lwl_thai_phonemic.tsv	lwl	Eastern Lawa	Eastern Lawa	Thai		False	Phonemic	False	253
 arz_arab_phonemic.tsv	arz	Egyptian Arabic	Egyptian Arabic	Arabic		False	Phonemic	False	113
 egy_latn_phonemic.tsv	egy	Egyptian (Ancient)	Egyptian	Latin		False	Phonemic	False	3403
-eng_latn_uk_phonemic_filtered.tsv	eng	English	English	Latin	UK, Received Pronunciation	True	Phonemic	True	60422
-eng_latn_us_phonemic_filtered.tsv	eng	English	English	Latin	US, General American	True	Phonemic	True	57230
 eng_latn_us_phonemic.tsv	eng	English	English	Latin	US, General American	False	Phonemic	True	58072
+eng_latn_us_phonemic_filtered.tsv	eng	English	English	Latin	US, General American	True	Phonemic	True	57230
 eng_latn_uk_phonemic.tsv	eng	English	English	Latin	UK, Received Pronunciation	False	Phonemic	True	61173
-eng_latn_us_phonetic.tsv	eng	English	English	Latin	US, General American	False	Phonetic	True	1633
+eng_latn_uk_phonemic_filtered.tsv	eng	English	English	Latin	UK, Received Pronunciation	True	Phonemic	True	60422
 eng_latn_uk_phonetic.tsv	eng	English	English	Latin	UK, Received Pronunciation	False	Phonetic	True	1284
+eng_latn_us_phonetic.tsv	eng	English	English	Latin	US, General American	False	Phonetic	True	1633
 epo_latn_phonemic.tsv	epo	Esperanto	Esperanto	Latin		False	Phonemic	True	14990
 est_latn_phonemic.tsv	est	Estonian	Estonian	Latin		False	Phonemic	True	429
 ewe_latn_phonemic.tsv	ewe	Ewe	Ewe	Latin		False	Phonemic	True	120
@@ -87,8 +87,8 @@ fre_latn_phonetic.tsv	fre	French	French	Latin		False	Phonetic	True	194
 glg_latn_phonemic.tsv	glg	Galician	Galician	Latin		False	Phonemic	True	4887
 glg_latn_phonetic.tsv	glg	Galician	Galician	Latin		False	Phonetic	True	1670
 kld_latn_phonemic.tsv	kld	Gamilaraay	Gamilaraay	Latin		False	Phonemic	True	454
-geo_geor_phonemic_filtered.tsv	geo	Georgian	Georgian	Georgian		True	Phonemic	False	15123
 geo_geor_phonemic.tsv	geo	Georgian	Georgian	Georgian		False	Phonemic	False	15124
+geo_geor_phonemic_filtered.tsv	geo	Georgian	Georgian	Georgian		True	Phonemic	False	15123
 ger_latn_phonemic.tsv	ger	German	German	Latin		False	Phonemic	True	35486
 ger_latn_phonemic_filtered.tsv	ger	German	German	Latin		True	Phonemic	True	34145
 ger_latn_phonetic.tsv	ger	German	German	Latin		False	Phonetic	True	10984
@@ -109,8 +109,8 @@ acw_arab_phonetic.tsv	acw	Hijazi Arabic	Hijazi Arabic	Arabic		False	Phonetic	Fal
 hin_deva_phonemic.tsv	hin	Hindi	Hindi	Devanagari		False	Phonemic	False	11296
 hin_deva_phonemic_filtered.tsv	hin	Hindi	Hindi	Devanagari		True	Phonemic	False	10812
 hin_deva_phonetic.tsv	hin	Hindi	Hindi	Devanagari		False	Phonetic	False	9563
-hun_latn_phonetic.tsv	hun	Hungarian	Hungarian	Latin		False	Phonetic	True	55595
 hun_latn_phonetic_filtered.tsv	hun	Hungarian	Hungarian	Latin		True	Phonetic	True	55533
+hun_latn_phonetic.tsv	hun	Hungarian	Hungarian	Latin		False	Phonetic	True	55595
 hrx_latn_phonemic.tsv	hrx	Hunsrik	Hunsrik	Latin		False	Phonemic	True	1545
 ice_latn_phonemic_filtered.tsv	ice	Icelandic	Icelandic	Latin		True	Phonemic	True	9524
 ice_latn_phonemic.tsv	ice	Icelandic	Icelandic	Latin		False	Phonemic	True	9578
@@ -124,13 +124,13 @@ izh_latn_phonemic.tsv	izh	Ingrian	Ingrian	Latin		False	Phonemic	True	737
 ina_latn_phonemic.tsv	ina	Interlingua (International Auxiliary Language Association)	Interlingua	Latin		False	Phonemic	True	265
 gle_latn_phonemic.tsv	gle	Irish	Irish	Latin		False	Phonemic	True	7328
 gle_latn_phonetic.tsv	gle	Irish	Irish	Latin		False	Phonetic	True	1575
-ita_latn_phonemic.tsv	ita	Italian	Italian	Latin		False	Phonemic	True	15014
 ita_latn_phonemic_filtered.tsv	ita	Italian	Italian	Latin		True	Phonemic	True	14476
+ita_latn_phonemic.tsv	ita	Italian	Italian	Latin		False	Phonemic	True	15014
 ita_latn_phonetic.tsv	ita	Italian	Italian	Latin		False	Phonetic	True	6075
 jam_latn_phonemic.tsv	jam	Jamaican Creole English	Jamaican Creole	Latin		False	Phonemic	True	147
 jpn_hira_phonetic_filtered.tsv	jpn	Japanese	Japanese	Hiragana		True	Phonetic	False	19689
-jpn_kana_phonetic_filtered.tsv	jpn	Japanese	Japanese	Katakana		True	Phonetic	False	4765
 jpn_hira_phonetic.tsv	jpn	Japanese	Japanese	Hiragana		False	Phonetic	False	19930
+jpn_kana_phonetic_filtered.tsv	jpn	Japanese	Japanese	Katakana		True	Phonetic	False	4765
 jpn_kana_phonetic.tsv	jpn	Japanese	Japanese	Katakana		False	Phonetic	False	5268
 jje_hang_phonemic.tsv	jje	Jejueo	Jeju	Hangul		False	Phonemic	False	1006
 kbd_cyrl_phonetic.tsv	kbd	Kabardian	Kabardian	Cyrillic		False	Phonetic	True	834
@@ -140,6 +140,7 @@ khm_khmr_phonemic_filtered.tsv	khm	Khmer	Khmer	Khmer		True	Phonemic	False	3208
 khm_khmr_phonemic.tsv	khm	Khmer	Khmer	Khmer		False	Phonemic	False	3411
 cnk_latn_phonemic.tsv	cnk	Khumi Chin	Khumi Chin	Latin		False	Phonemic	True	307
 kik_latn_phonemic.tsv	kik	Kikuyu	Kikuyu	Latin		False	Phonemic	True	1129
+kpv_cyrl_phonemic.tsv	kpv	Komi-Zyrian	Komi-Zyrian	Cyrillic		False	Phonemic		321
 kor_hang_phonetic.tsv	kor	Korean	Korean	Hangul		False	Phonetic	False	16402
 kor_hang_phonetic_filtered.tsv	kor	Korean	Korean	Hangul		True	Phonetic	False	14141
 kir_cyrl_phonemic.tsv	kir	Kirghiz	Kyrgyz	Cyrillic		False	Phonemic	True	101
@@ -148,14 +149,14 @@ lad_latn_phonemic.tsv	lad	Ladino	Ladino	Latin		False	Phonemic	True	101
 lao_laoo_phonemic.tsv	lao	Lao	Lao	Lao		False	Phonemic	False	513
 lsi_latn_phonemic.tsv	lsi	Lashi	Lashi	Latin		False	Phonemic	True	300
 ltg_latn_phonetic.tsv	ltg	Latgalian	Latgalian	Latin		False	Phonetic	True	125
-lat_latn_clas_phonemic.tsv	lat	Latin	Latin	Latin	Classical	False	Phonemic	True	33333
-lat_latn_eccl_phonemic.tsv	lat	Latin	Latin	Latin	Ecclesiastical	False	Phonemic	True	32334
 lat_latn_vulg_phonemic.tsv	lat	Latin	Latin	Latin	Vulgar	False	Phonemic	True	508
+lat_latn_eccl_phonemic.tsv	lat	Latin	Latin	Latin	Ecclesiastical	False	Phonemic	True	32334
+lat_latn_clas_phonemic.tsv	lat	Latin	Latin	Latin	Classical	False	Phonemic	True	33333
 lat_latn_eccl_phonetic.tsv	lat	Latin	Latin	Latin	Ecclesiastical	False	Phonetic	True	31750
-lat_latn_clas_phonetic.tsv	lat	Latin	Latin	Latin	Classical	False	Phonetic	True	32715
 lat_latn_vulg_phonetic.tsv	lat	Latin	Latin	Latin	Vulgar	False	Phonetic	True	481
-lav_latn_phonetic.tsv	lav	Latvian	Latvian	Latin		False	Phonetic	True	1291
+lat_latn_clas_phonetic.tsv	lat	Latin	Latin	Latin	Classical	False	Phonetic	True	32715
 lav_latn_phonetic_filtered.tsv	lav	Latvian	Latvian	Latin		True	Phonetic	True	1230
+lav_latn_phonetic.tsv	lav	Latvian	Latvian	Latin		False	Phonetic	True	1291
 ayl_arab_phonemic.tsv	ayl	Libyan Arabic	Libyan Arabic	Arabic		False	Phonemic	False	157
 lij_latn_phonemic.tsv	lij	Ligurian	Ligurian	Latin		False	Phonemic	True	756
 lif_limb_phonemic.tsv	lif	Limbu	Limbu	Limbu		False	Phonemic	False	108
@@ -177,8 +178,8 @@ may_latn_phonemic.tsv	may	Malay (macrolanguage)	Malay	Latin		False	Phonemic	True
 may_arab_ara_phonemic.tsv	may	Malay (macrolanguage)	Malay	Arabic		False	Phonemic	True	628
 may_arab_ara_phonetic.tsv	may	Malay (macrolanguage)	Malay	Arabic		False	Phonetic	True	220
 may_latn_phonetic.tsv	may	Malay (macrolanguage)	Malay	Latin		False	Phonetic	True	444
-mlt_latn_phonemic.tsv	mlt	Maltese	Maltese	Latin		False	Phonemic	True	4609
 mlt_latn_phonemic_filtered.tsv	mlt	Maltese	Maltese	Latin		True	Phonemic	True	4035
+mlt_latn_phonemic.tsv	mlt	Maltese	Maltese	Latin		False	Phonemic	True	4609
 mnc_mong_phonetic.tsv	mnc	Manchu	Manchu	Mongolian		False	Phonetic	False	890
 glv_latn_phonemic.tsv	glv	Manx	Manx	Latin		False	Phonemic	True	202
 glv_latn_phonetic.tsv	glv	Manx	Manx	Latin		False	Phonetic	True	125
@@ -242,21 +243,21 @@ phl_latn_phonemic.tsv	phl	Phalura	Phalura	Latin		False	Phonemic	True	2227
 pms_latn_phonemic.tsv	pms	Piemontese	Piedmontese	Latin		False	Phonemic	True	732
 ppl_latn_phonemic.tsv	ppl	Pipil	Pipil	Latin		False	Phonemic	True	263
 pjt_latn_phonetic.tsv	pjt	Pitjantjatjara	Pitjantjatjara	Latin		False	Phonetic	True	125
-crk_cans_phonemic.tsv	crk	Plains Cree	Plains Cree	Canadian Aboriginal		False	Phonemic	True	152
 crk_latn_phonemic.tsv	crk	Plains Cree	Plains Cree	Latin		False	Phonemic	True	193
+crk_cans_phonemic.tsv	crk	Plains Cree	Plains Cree	Canadian Aboriginal		False	Phonemic	True	152
 pbv_latn_phonemic.tsv	pbv	Pnar	Pnar	Latin		False	Phonemic	True	101
 pox_latn_phonemic.tsv	pox	Polabian	Polabian	Latin		False	Phonemic	True	228
 pol_latn_phonemic.tsv	pol	Polish	Polish	Latin		False	Phonemic	True	71863
-por_latn_po_phonemic_filtered.tsv	por	Portuguese	Portuguese	Latin	Portugal	True	Phonemic	True	9800
-por_latn_po_phonemic.tsv	por	Portuguese	Portuguese	Latin	Portugal	False	Phonemic	True	10122
 por_latn_bz_phonemic_filtered.tsv	por	Portuguese	Portuguese	Latin	Brazil	True	Phonemic	True	11331
+por_latn_po_phonemic.tsv	por	Portuguese	Portuguese	Latin	Portugal	False	Phonemic	True	10122
+por_latn_po_phonemic_filtered.tsv	por	Portuguese	Portuguese	Latin	Portugal	True	Phonemic	True	9800
 por_latn_bz_phonemic.tsv	por	Portuguese	Portuguese	Latin	Brazil	False	Phonemic	True	11489
-por_latn_bz_phonetic.tsv	por	Portuguese	Portuguese	Latin	Brazil	False	Phonetic	True	953
 por_latn_po_phonetic.tsv	por	Portuguese	Portuguese	Latin	Portugal	False	Phonetic	True	312
+por_latn_bz_phonetic.tsv	por	Portuguese	Portuguese	Latin	Brazil	False	Phonetic	True	953
 pan_guru_phonemic.tsv	pan	Panjabi	Punjabi	Gurmukhi		False	Phonemic	False	139
 rum_latn_phonemic.tsv	rum	Romanian; Moldavian; Moldovan	Romanian	Latin		False	Phonemic	True	4103
-rum_latn_phonetic_filtered.tsv	rum	Romanian; Moldavian; Moldovan	Romanian	Latin		True	Phonetic	True	6271
 rum_latn_phonetic.tsv	rum	Romanian; Moldavian; Moldovan	Romanian	Latin		False	Phonetic	True	6377
+rum_latn_phonetic_filtered.tsv	rum	Romanian; Moldavian; Moldovan	Romanian	Latin		True	Phonetic	True	6271
 rus_cyrl_phonetic.tsv	rus	Russian	Russian	Cyrillic		False	Phonetic	True	402586
 san_deva_phonemic.tsv	san	Sanskrit	Sanskrit	Devanagari		False	Phonemic	False	6839
 san_deva_phonetic.tsv	san	Sanskrit	Sanskrit	Devanagari		False	Phonetic	False	673
@@ -266,10 +267,10 @@ sco_latn_phonemic.tsv	sco	Scots	Scots	Latin		False	Phonemic	True	900
 sco_latn_phonetic.tsv	sco	Scots	Scots	Latin		False	Phonetic	True	438
 gla_latn_phonemic.tsv	gla	Gaelic; Scottish Gaelic	Scottish Gaelic	Latin		False	Phonemic	True	1362
 gla_latn_phonetic.tsv	gla	Gaelic; Scottish Gaelic	Scottish Gaelic	Latin		False	Phonetic	True	107
-hbs_latn_phonemic.tsv	hbs	Serbo-Croatian	Serbo-Croatian	Latin		False	Phonemic	True	23827
 hbs_cyrl_phonemic_filtered.tsv	hbs	Serbo-Croatian	Serbo-Croatian	Cyrillic		True	Phonemic	True	22543
-hbs_latn_phonemic_filtered.tsv	hbs	Serbo-Croatian	Serbo-Croatian	Latin		True	Phonemic	True	23517
 hbs_cyrl_phonemic.tsv	hbs	Serbo-Croatian	Serbo-Croatian	Cyrillic		False	Phonemic	True	22735
+hbs_latn_phonemic_filtered.tsv	hbs	Serbo-Croatian	Serbo-Croatian	Latin		True	Phonemic	True	23517
+hbs_latn_phonemic.tsv	hbs	Serbo-Croatian	Serbo-Croatian	Latin		False	Phonemic	True	23827
 shn_mymr_phonemic.tsv	shn	Shan	Shan	Myanmar		False	Phonemic	False	487
 scn_latn_phonemic.tsv	scn	Sicilian	Sicilian	Latin		False	Phonemic	True	855
 scn_latn_phonetic.tsv	scn	Sicilian	Sicilian	Latin		False	Phonetic	True	287
@@ -278,12 +279,12 @@ slo_latn_phonetic.tsv	slo	Slovak	Slovak	Latin		False	Phonetic	True	1620
 slv_latn_phonemic_filtered.tsv	slv	Slovenian	Slovene	Latin		True	Phonemic	True	4390
 slv_latn_phonemic.tsv	slv	Slovenian	Slovene	Latin		False	Phonemic	True	4396
 ajp_arab_phonemic.tsv	ajp	South Levantine Arabic	South Levantine Arabic	Arabic		False	Phonemic	False	155
-spa_latn_la_phonemic.tsv	spa	Spanish; Castilian	Spanish	Latin	Latin America	False	Phonemic	True	48718
-spa_latn_la_phonemic_filtered.tsv	spa	Spanish; Castilian	Spanish	Latin	Latin America	True	Phonemic	True	48649
-spa_latn_ca_phonemic_filtered.tsv	spa	Spanish; Castilian	Spanish	Latin	Castilian	True	Phonemic	True	60677
 spa_latn_ca_phonemic.tsv	spa	Spanish; Castilian	Spanish	Latin	Castilian	False	Phonemic	True	60805
-spa_latn_la_phonetic.tsv	spa	Spanish; Castilian	Spanish	Latin	Latin America	False	Phonetic	True	41854
+spa_latn_la_phonemic.tsv	spa	Spanish; Castilian	Spanish	Latin	Latin America	False	Phonemic	True	48718
+spa_latn_ca_phonemic_filtered.tsv	spa	Spanish; Castilian	Spanish	Latin	Castilian	True	Phonemic	True	60677
+spa_latn_la_phonemic_filtered.tsv	spa	Spanish; Castilian	Spanish	Latin	Latin America	True	Phonemic	True	48649
 spa_latn_ca_phonetic.tsv	spa	Spanish; Castilian	Spanish	Latin	Castilian	False	Phonetic	True	52190
+spa_latn_la_phonetic.tsv	spa	Spanish; Castilian	Spanish	Latin	Latin America	False	Phonetic	True	41854
 srn_latn_phonemic.tsv	srn	Sranan Tongo	Sranan Tongo	Latin		False	Phonemic	True	162
 swe_latn_phonemic.tsv	swe	Swedish	Swedish	Latin		False	Phonemic	True	3544
 swe_latn_phonetic.tsv	swe	Swedish	Swedish	Latin		False	Phonetic	True	222
@@ -301,28 +302,28 @@ tha_thai_phonemic.tsv	tha	Thai	Thai	Thai		False	Phonemic	False	15050
 tib_tibt_phonemic.tsv	tib	Tibetan	Tibetan	Tibetan		False	Phonemic	False	1875
 ton_latn_phonemic.tsv	ton	Tonga (Tonga Islands)	Tongan	Latin		False	Phonemic	True	154
 tur_latn_phonemic.tsv	tur	Turkish	Turkish	Latin		False	Phonemic	True	1789
-tur_latn_phonetic.tsv	tur	Turkish	Turkish	Latin		False	Phonetic	True	2043
 tur_latn_phonetic_filtered.tsv	tur	Turkish	Turkish	Latin		True	Phonetic	True	1812
+tur_latn_phonetic.tsv	tur	Turkish	Turkish	Latin		False	Phonetic	True	2043
 tuk_latn_phonemic.tsv	tuk	Turkmen	Turkmen	Latin		False	Phonemic	True	107
 tyv_cyrl_phonemic.tsv	tyv	Tuvinian	Tuvan	Cyrillic		False	Phonemic	True	462
 ukr_cyrl_phonetic.tsv	ukr	Ukrainian	Ukrainian	Cyrillic		False	Phonetic	True	6148
 urd_arab_phonemic.tsv	urd	Urdu	Urdu	Arabic		False	Phonemic	False	1063
 uig_arab_ara_phonemic.tsv	uig	Uighur	Uyghur	Arabic		False	Phonemic	True	260
-vie_latn_hanoi_phonetic_filtered.tsv	vie	Vietnamese	Vietnamese	Latin	Hà Nội	True	Phonetic	True	15240
 vie_latn_hanoi_phonetic.tsv	vie	Vietnamese	Vietnamese	Latin	Hà Nội	False	Phonetic	True	15240
-vie_latn_hue_phonetic_filtered.tsv	vie	Vietnamese	Vietnamese	Latin	Huế	True	Phonetic	True	15236
-vie_latn_hcmc_phonetic_filtered.tsv	vie	Vietnamese	Vietnamese	Latin	Hồ Chí Minh City	True	Phonetic	True	14537
 vie_latn_hue_phonetic.tsv	vie	Vietnamese	Vietnamese	Latin	Huế	False	Phonetic	True	15239
 vie_latn_hcmc_phonetic.tsv	vie	Vietnamese	Vietnamese	Latin	Hồ Chí Minh City	False	Phonetic	True	15237
+vie_latn_hanoi_phonetic_filtered.tsv	vie	Vietnamese	Vietnamese	Latin	Hà Nội	True	Phonetic	True	15240
+vie_latn_hcmc_phonetic_filtered.tsv	vie	Vietnamese	Vietnamese	Latin	Hồ Chí Minh City	True	Phonetic	True	14537
+vie_latn_hue_phonetic_filtered.tsv	vie	Vietnamese	Vietnamese	Latin	Huế	True	Phonetic	True	15236
 vol_latn_phonemic.tsv	vol	Volapük	Volapük	Latin		False	Phonemic	True	363
 vol_latn_phonetic.tsv	vol	Volapük	Volapük	Latin		False	Phonetic	True	565
 wau_latn_phonemic.tsv	wau	Waurá	Wauja	Latin		False	Phonemic	True	152
-wel_latn_sw_phonemic_filtered.tsv	wel	Welsh	Welsh	Latin	South Wales	True	Phonemic	True	9925
 wel_latn_nw_phonemic_filtered.tsv	wel	Welsh	Welsh	Latin	North Wales	True	Phonemic	True	8473
+wel_latn_sw_phonemic_filtered.tsv	wel	Welsh	Welsh	Latin	South Wales	True	Phonemic	True	9925
 wel_latn_nw_phonemic.tsv	wel	Welsh	Welsh	Latin	North Wales	False	Phonemic	True	8530
 wel_latn_sw_phonemic.tsv	wel	Welsh	Welsh	Latin	South Wales	False	Phonemic	True	9999
-wel_latn_nw_phonetic.tsv	wel	Welsh	Welsh	Latin	North Wales	False	Phonetic	True	561
 wel_latn_sw_phonetic.tsv	wel	Welsh	Welsh	Latin	South Wales	False	Phonetic	True	601
+wel_latn_nw_phonetic.tsv	wel	Welsh	Welsh	Latin	North Wales	False	Phonetic	True	561
 fry_latn_phonemic.tsv	fry	Western Frisian	West Frisian	Latin		False	Phonemic	True	977
 apw_latn_phonetic.tsv	apw	Western Apache	Western Apache	Latin		False	Phonetic	True	158
 mww_latn_phonemic.tsv	mww	Hmong Daw	White Hmong	Latin		False	Phonemic	True	322


### PR DESCRIPTION
For some reason this fell through the cracks before.

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
