### PR TITLE
Fix ordering in data/covering_grammar/make_test_file.py

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ Unreleased
 -   Renamed TSV files and phonelists to use the terms "broad"/"narrow" instead
     of "phonemic"/"phonetic" (\#389, \#402, \#405)
 -   Fixed typo in `README.md` (\#407)
+-   Fixed order of data in `data/covering_grammar/lib/make_test_file.py` (\#410)
 
 ### Under `wikipron/` and elsewhere
 

--- a/data/covering_grammar/lib/make_test_file.py
+++ b/data/covering_grammar/lib/make_test_file.py
@@ -25,7 +25,7 @@ def main(args: argparse.Namespace) -> None:
             if g_word != p_word:
                 logging.error("%s != %s (line %d)", g_word, p_word, lineno)
                 exit(1)
-            print(f"{g_word}\t{g_pron}\t{p_pron}", file=wf)
+            print(f"{g_word}\t{p_pron}\t{g_pron}", file=wf)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.

I had accidentally written `make_test_file.py` to make the test file with the order "word gold-pronunciation predicted-pronunication" when in fact `data/covering_grammar/make_test_file.py` needs the predicted pronunciation before the gold pronunication. This PR fixes that.

(@Othergreengrasses )