### PR TITLE
Makassarese: New scrape. Also, a bug fix for invoking _remove_mismatch_ids in languages_update.py 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ Unreleased
 -   Added `data/covering_grammar/tsv/fre_latn_phonemic.tsv` (\#398)
 -   Added `data/covering_grammar/lib/make_test_file.py` (\#396, \#399)
 -   Scraped Komi-Zyrian (`kpv`). (\#400)
+-   Scraped Makasar (`mak`). (\#415)
 
 #### Changed
 

--- a/data/scrape/README.md
+++ b/data/scrape/README.md
@@ -192,6 +192,7 @@
 | [TSV](tsv/mac_cyrl_narrow.tsv) | mac | Macedonian | Macedonian | Cyrillic |  | False | Narrow | True | 6,878 |
 | [TSV](tsv/mah_latn_broad.tsv) | mah | Marshallese | Marshallese | Latin |  | False | Broad | True | 900 |
 | [TSV](tsv/mah_latn_narrow.tsv) | mah | Marshallese | Marshallese | Latin |  | False | Narrow | True | 1,502 |
+| [TSV](tsv/mak_latn_narrow.tsv) | mak | Makasar | Makasar | Latin |  | False | Narrow | True | 220 |
 | [TSV](tsv/mar_deva_broad.tsv) | mar | Marathi | Marathi | Devanagari |  | False | Broad | False | 588 |
 | [TSV](tsv/mar_deva_narrow.tsv) | mar | Marathi | Marathi | Devanagari |  | False | Narrow | False | 118 |
 | [TSV](tsv/may_arab_ara_broad.tsv) | may | Malay (macrolanguage) | Malay | Arabic |  | False | Broad | True | 628 |

--- a/data/scrape/lib/languages.json
+++ b/data/scrape/lib/languages.json
@@ -1110,7 +1110,10 @@
         "iso639_name": "Makasar",
         "wiktionary_name": "Makasar",
         "wiktionary_code": "mak",
-        "casefold": null
+        "casefold": true,
+        "script": {
+            "latn": "Latin"
+        }
     },
     "mlg": {
         "iso639_name": "Malagasy",

--- a/data/scrape/lib/languages_update.py
+++ b/data/scrape/lib/languages_update.py
@@ -28,7 +28,7 @@ def _detect_best_script_name(
     word belongs to along with the corresponding confidence expressed as a
     maximum likelihood estimate computed over the `word` sample. If `strict`
     is enabled, then all the characters must belong to the same script and
-    `(None, None)` is returned on failure.
+    `None` is returned on failure.
 
     Example: "ژۇرنال" -> ("Arabic", 1.0).
     """
@@ -69,7 +69,7 @@ def _get_alias(
     script = "".join(
         unicodedataplus.property_value_aliases["script"][value]
     ).lower()
-    # Removes qaac tag from end of script.
+    # Removes `qaac/qaai` tags from end of script.
     return script.replace("qaac", "").replace("qaai", "")
 
 
@@ -131,7 +131,7 @@ def main():
                                 lang["script"][
                                     _get_alias(script)
                                 ] = script.replace("_", " ")
-                        _remove_mismatch_ids(lang)
+                            _remove_mismatch_ids(lang)
     with open(LANGUAGES_PATH, "w", encoding="utf-8") as sink:
         json.dump(languages, sink, ensure_ascii=False, indent=4)
 

--- a/data/scrape/tsv/mak_latn_narrow.tsv
+++ b/data/scrape/tsv/mak_latn_narrow.tsv
@@ -1,0 +1,220 @@
+abang	a b a ŋ
+accokko	a cː ɔ kː ɔ
+agang	a ɡ a ŋ
+akkana	a kː a n a
+akkangkang	a kː a ŋ k a ŋ
+akkeke	a kː ɛ k ɛ
+alle	a lː ɛ
+allo	a lː ɔ
+alloi	a lː o i
+ambani	a m b a n i
+ammalli	a mː a lː i
+ammenteng	e n t e ŋ
+ammera	a mː e r a
+amminro	a mː i n r o
+ammisang	a mː i s a ŋ
+ammuko	a mː u k ɔ
+anggappa	a ŋ ɡ a pː a
+anging	a ŋ i ŋ
+anjama	a ɲ ɟ a m a
+anjo	a ɲ ɟ ɔ
+anjoreng	a ɲ ɟ o r e ŋ
+annampiling	a nː a m p i l i ŋ
+annang	a nː a ŋ
+anne	a nː ɛ
+anngai	a ŋː a i
+anngalimbuki	a ŋː a l i m b u k i
+anngalle	a ŋː a lː ɛ
+anngalloi	a ŋː a lː o i
+anngalotori	a ŋː a l o t o r i
+anngangkang	a ŋː a ŋ k a ŋ
+annganre	a ŋː a n r ɛ
+anngerang	a ŋː e r a ŋ
+annginrang	a ŋː i n r a ŋ
+annginung	a ŋː i n u ŋ
+anngisseng	a ŋː i sː e ŋ
+anngondang	a ŋː o n d a ŋ
+anngota	a ŋː o t a
+annyokko	a ɳː ɔ kː ɔ
+annyungke	a ɲː u ŋ k ɛ
+anrappung	a n r a pː u ŋ
+anrinni	a n r i nː i
+antu	a n t u
+antureng	a n t u r e ŋ
+appaenteng	a pː a e n t e ŋ
+appainro	a pː a i n r o
+appallu	a pː a l l u
+apparinra	a pː a r i n r a
+appilanngeri	a pː i l a ŋː e r i
+appirassi	a pː i r a sː i
+araba	a r a b a
+areng	a r e ŋ
+ase	a s ɛ
+assare	a sː a r ɛ
+assassa	a sː a sː a
+assuro	a sː u r ɔ
+attayang	a tː a j a ŋ
+au	a u
+baine	b a i n ɛ
+balao	b a l a ɔ
+balli	b a lː i
+bambang	b a m b a ŋ
+bangkeng	b a ŋ k e ŋ
+barambang	b a r a m b a ŋ
+battang	b a tː a ŋ
+bawa	b a w a
+bawi	b a w i
+bayao	b a j a ɔ
+bebe	b ɛ b ɛ
+bedeng	b e d e ŋ
+bella	b e lː a
+benteng	b e n t e ŋ
+berang	b e r a ŋ
+beru	b e r u
+binanga	b i n a ŋ a
+biralle	b i r a lː ɛ
+bise	b i s ɛ
+biseang	b i s ɛ a ŋ
+bodo	b ɔ d ɔ
+bongga	b o ŋ ɡ a
+boya	b o j a
+bukkuleng	b u kː u l e ŋ
+buku	b u k u
+bulang	b u l a ŋ
+bulo	b u l ɔ
+bungung	b u ŋ u ŋ
+butta	b u tː a
+carammeng	c a r a mː e ŋ
+cikali	c i k a l i
+cokko	c ɔ kː ɔ
+dengka	d e ŋ k a
+dinging	d i ŋ i ŋ
+doang	d ɔ a ŋ
+eja	e ɟ a
+erang	e r a ŋ
+gappa	ɡ a pː a
+garring	ɡ a rː i ŋ
+garu	ɡ a r u
+gassing	ɡ a sː i ŋ
+ingkong	i ŋ k o ŋ
+inrang	i n r a ŋ
+inung	i n u ŋ
+isseng	i sː e ŋ
+jama	ɟ a m a
+jamang	ɟ a m a ŋ
+jangang	ɟ a ŋ a ŋ
+jangka	ɟ a ŋ k a
+kaeroki	k a e r o k i
+kalarroang	k a l a rː ɔ a ŋ
+kalarroi	k a l a rː o i
+kale	k a l ɛ
+kalimbuki	k a l i m b u k i
+kallong	k a lː o ŋ
+kalotori	k a l o t o r i
+kaluku	k a l u k u
+kamallakkang	k a m a lː a kː a ŋ
+kambe	k a m b ɛ
+kana	k a n a
+kangkang	k a ŋ k a ŋ
+kannying	k a ɲː i ŋ
+kanre	k a n r ɛ
+karemeng	k a r e m e ŋ
+karruki	k a rː u k i
+karueng	k a r u e ŋ
+katimbang	k a t i m b a ŋ
+katinting	k a t i n t i ŋ
+katte	k a tː ɛ
+keke	k ɛ k ɛ
+koko	k ɔ k ɔ
+kongkong	k o ŋ k o ŋ
+kota	k o t a
+kuttu	k u tː u
+kutu	k u t u
+lading	l a d i ŋ
+lamung	l a m u ŋ
+lamungang	l a m u ŋ a ŋ
+lantang	l a n t a ŋ
+larro	l a rː ɔ
+laso	l a s ɔ
+lembarang	l e m b a r a ŋ
+lila	l i l a
+lima	l i m a
+lolo	l ɔ l ɔ
+lompo	l ɔ m p ɔ
+londeng	l o n d e ŋ
+mangge	m a ŋ ɡ e
+mata	m a t a
+miong	m i o ŋ
+moncong	m o ɲ c o ŋ
+nakke	n a kː ɛ
+naung	n a u ŋ
+ngai	ŋ a i
+ondang	o n d a ŋ
+ongkosi	o ŋ k o s i
+paenteng	p a e n t e ŋ
+painro	p a i n r o
+paja	p a ɟ a
+pakkuttuang	p a kː u tː u a ŋ
+pallu	p a lː u
+panne	p a nː ɛ
+paranggi	p a r a ŋ ɡ i
+parinra	p a r i n r a
+pera	p e r a
+pilanngeri	p i l a ŋː e r i
+pinruang	p i n r u a ŋ
+pirassi	p i r a sː i
+pisang	p i s a ŋ
+poterang	p o t e r a ŋ
+rappo	r a pː ɔ
+rappung	r a pː u ŋ
+rassi	r a sː i
+rate	r a t ɛ
+rawa	r a w a
+raya	r a j a
+ri	r i
+rinra	r i n r a
+rinring	r i n r i ŋ
+romang	r o m a ŋ
+rua	r u a
+sagantuju	s a ɡ a n t u ɟ u
+salapang	s a l a p a ŋ
+salasa	s a l a s a
+sallang	s a lː a ŋ
+sallo	s a lː ɔ
+sambawa	s a m b a w a
+sampo	s a m p ɔ
+sampulo	s a m p u l ɔ
+sanneng	s a nː e ŋ
+sare	s a r ɛ
+sassa	s a sː a
+sassang	s a sː a ŋ
+sedeng	s e d e ŋ
+sikali	s i k a l i
+sikuyu	s i k u j u
+sombong	s o m b o ŋ
+subanngi	s u b a ŋː i
+subanngiangang	s u b a ŋː i a ŋ a ŋ
+sumpadeng	s u m p a d e ŋ
+sungke	s u ŋ k ɛ
+suro	s u r ɔ
+tai	t a i
+taipa	t a i p a
+talipong	t a l i p o ŋ
+tallu	t a lː u
+tamparang	t a m p a r a ŋ
+tampiling	t a m p i l i ŋ
+tana	t a n a
+tara	t a r a
+tarang	t a r a ŋ
+tarawe	t a r a w ɛ
+tayang	t a j a ŋ
+tedong	t e d o ŋ
+telang	t e l a ŋ
+tena	t e n a
+toana	t ɔ a n a
+toli	t o l i
+tuju	t u ɟ u
+uang	u a ŋ
+ulu	u l u
+unti	u n t i
+uring	u r i ŋ

--- a/data/scrape/tsv_summary.tsv
+++ b/data/scrape/tsv_summary.tsv
@@ -190,6 +190,7 @@ lwl_thai_broad.tsv	lwl	Eastern Lawa	Eastern Lawa	Thai		False	Broad	False	253
 mac_cyrl_narrow.tsv	mac	Macedonian	Macedonian	Cyrillic		False	Narrow	True	6878
 mah_latn_broad.tsv	mah	Marshallese	Marshallese	Latin		False	Broad	True	900
 mah_latn_narrow.tsv	mah	Marshallese	Marshallese	Latin		False	Narrow	True	1502
+mak_latn_narrow.tsv	mak	Makasar	Makasar	Latin		False	Narrow	True	220
 mar_deva_broad.tsv	mar	Marathi	Marathi	Devanagari		False	Broad	False	588
 mar_deva_narrow.tsv	mar	Marathi	Marathi	Devanagari		False	Narrow	False	118
 may_arab_ara_broad.tsv	may	Malay (macrolanguage)	Malay	Arabic		False	Broad	True	628


### PR DESCRIPTION
While scraping Makasar I discovered a bug: When `_detect_best_script_name` fails, `_remove_mismatch_ids` aborts because the `script` dictionary key is unset. This is now fixed by this PR. There is a slightly unrelated issue that I am going to open separately which concerns script detection and common characters.

- [x] Updated `Unreleased` in `CHANGELOG.md` to reflect the changes in code or data.
